### PR TITLE
Configured so program produces correct energy for the simplest case of 1

### DIFF
--- a/Hamiltonians/harmonicoscillator.cpp
+++ b/Hamiltonians/harmonicoscillator.cpp
@@ -25,9 +25,10 @@ double HarmonicOscillator::computeLocalEnergy(std::vector<Particle*> particles) 
      * m_system->getWaveFunction()...
      */
 
-	double potentialEnergy	= 0.5*m_omega;
+	double rr = particles[0]->getPosition()[0]*particles[0]->getPosition()[0];
+	double potentialEnergy	= 0.5*m_omega*rr;
 	double kineticEnergy	=
-		0.5*m_system->getWaveFunction()->computeDoubleDerivative(particles);
+		-0.5*m_system->getWaveFunction()->computeDoubleDerivative(particles);
 
     return kineticEnergy + potentialEnergy;
 }

--- a/system.cpp
+++ b/system.cpp
@@ -13,15 +13,22 @@ bool System::metropolisStep() {
      * change it's position by a random amount, and check if the step is
      * accepted by the Metropolis test (compare the wave function evaluated
      * at this new position with the one at the old position).
+	 *
+	 * double positionNew = m_particles[0]->getPosition()[0] +
+	 * m_stepLength*(Random::nextDouble() - .5);
+	 * std::vector<double> step(m_numberOfDimensions);
+	 * for( dim = 0; dim < m_numberOfDimensions; dim++ )
+	 * {
+	 * step[dim] = m_stepLength*2*(Random::nextDouble() - .5);
+	 * m_particles[]
+	 * }
      */
 
-	//double positionNew = m_particles[0]->getPosition()[0] +
-	//	m_stepLength*(Random::nextDouble() - .5);
-	
 	double wfold = m_waveFunction->evaluate(m_particles);
-
 	double step = m_stepLength*(Random::nextDouble() - .5);
+
 	m_particles[0]->adjustPosition(step, 0);
+
 	double wfnew = m_waveFunction->evaluate(m_particles);
 
 	if( Random::nextDouble() <= std::exp(2*(wfnew - wfold)) )


### PR DESCRIPTION
particle and 1 dimension. Error was a missing "-" in the expression for
kinetic energy. Output now as expected.

  -- System info --
 Number of particles  : 1
 Number of dimensions : 1
 Number of Metropolis steps run : 10^6
 Number of equilibration steps  : 10^5

  -- Wave function parameters --
 Number of parameters : 1
 Parameter 1 : 0.5

  -- Reults --
 Energy : 0.5