### PR TITLE
added dimensional considerations to r^2 in local energy for harmonic

### DIFF
--- a/Hamiltonians/harmonicoscillator.cpp
+++ b/Hamiltonians/harmonicoscillator.cpp
@@ -1,6 +1,7 @@
 #include "harmonicoscillator.h"
 #include <cassert>
 #include <iostream>
+#include <cmath>
 #include "../system.h"
 #include "../particle.h"
 #include "../WaveFunctions/wavefunction.h"
@@ -25,8 +26,12 @@ double HarmonicOscillator::computeLocalEnergy(std::vector<Particle*> particles) 
      * m_system->getWaveFunction()...
      */
 
-	double rr = particles[0]->getPosition()[0]*particles[0]->getPosition()[0];
-	double potentialEnergy	= 0.5*m_omega*rr;
+	double r2 = 0;
+	for( int dim=0; dim < m_system->getNumberOfDimensions(); dim++ )
+	{
+		r2 = std::pow(particles[0]->getPosition()[dim], 2);
+	}
+	double potentialEnergy	= 0.5*m_omega*r2;
 	double kineticEnergy	=
 		-0.5*m_system->getWaveFunction()->computeDoubleDerivative(particles);
 

--- a/WaveFunctions/simplegaussian.cpp
+++ b/WaveFunctions/simplegaussian.cpp
@@ -21,10 +21,12 @@ double SimpleGaussian::evaluate(std::vector<class Particle*> particles) {
      * For the actual expression, use exp(-alpha * r^2), with alpha being the
      * (only) variational parameter.
      */
-	double r2 = std::pow(particles[0]->getPosition()[0], 2);
+	double r2 = 0;
+	for( int dim = 0; dim < m_system->getNumberOfDimensions(); dim++ )
+	{
+		r2 += std::pow(particles[0]->getPosition()[dim], 2);
+	}
 	return -m_parameters[0]*r2;
-	//return std::exp( -m_parameters[0]*r2 );
-	//return 0;
 }
 
 double SimpleGaussian::computeDoubleDerivative(std::vector<class Particle*> particles) {
@@ -36,8 +38,48 @@ double SimpleGaussian::computeDoubleDerivative(std::vector<class Particle*> part
      * This quantity is needed to compute the (local) energy (consider the
      * Schrödinger equation to see how the two are related).
      */
-	return -2*m_parameters[0] + 4*pow(m_parameters[0], 2)
-		*std::pow(particles[0]->getPosition()[0], 2);
-		//*exp(-m_parameters[0]*pow)particles[0].getPosition(), 2)
-    //return 0;
+
+	double r2 = 0;
+	for( int dim = 0; dim < m_system->getNumberOfDimensions(); dim++ )
+	{
+		r2 += std::pow(particles[0]->getPosition()[dim], 2);
+	}
+	return -2*m_parameters[0] + 4*pow(m_parameters[0], 2)*r2;
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/system.h
+++ b/system.h
@@ -3,7 +3,7 @@
 
 class System {
 public:
-    bool metropolisStep             ();
+    bool metropolisStep             (int particle);
     void runMetropolisSteps         (int numberOfMetropolisSteps);
     void setNumberOfParticles       (int numberOfParticles);
     void setNumberOfDimensions      (int numberOfDimensions);


### PR DESCRIPTION
oscillator

Added in loop over particles in Metropolissteps

Checks for the equilibration ratio. This means the result is not quite .5, though
it is close.

So far, only metropolisStep() takes in the particle and
does not need to send it further down the stack

run results:
  -- System info --
 Number of particles  : 1
 Number of dimensions : 1
 Number of Metropolis steps run : 10^6
 Number of equilibration steps  : 10^5

  -- Wave function parameters --
 Number of parameters : 1
 Parameter 1 : 0.5

  -- Reults --
 Energy : 0.449999