### PR TITLE
Changes to main and sampler are print statements and comments. the code

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -30,7 +30,7 @@ int main() {
 
 
     int numberOfDimensions[]    = {3}; // {1, 2, 3};
-    int numberOfParticles[]     = {1,3}; //{1,10,100,500};
+    int numberOfParticles[]     = {1}; //,3}; //{1,10,100,500};
     int numberOfSteps           = (int) 1e5;
     double omega                = 1.0;              // Oscillator frequency.
     vector<double> alpha        = {.5};// Variational parameter.
@@ -104,6 +104,8 @@ int main() {
                         double currEnergy = system->getSdRes()[0];
                         double currDeltaPsi = system->getSdRes()[1];
                         double currDerivativePsiE = system->getSdRes()[2];
+						std::cout << "gradient: " << std::endl;
+						std::cout << currDerivativePsiE - currEnergy*currDeltaPsi << std::endl;
                         alphaChange = eta*2*(currDerivativePsiE - currEnergy*currDeltaPsi);
                         alpha_guess -= alphaChange;
 

--- a/resampling.py
+++ b/resampling.py
@@ -2,12 +2,16 @@
 
 import os 
 
+import csv
 import numpy as np
-from numpy.random import randint
 from time import time
+from scipy.stats import norm
+import matplotlib.pyplot as plt
+from numpy.random import randint
 
 #where to save data
-DATA_ID = "build/results"
+#DATA_ID = "build/results"
+DATA_ID = "results_1c"
 
 def data_path(data_id): 
     return os.path.join(DATA_ID, data_id)
@@ -30,10 +34,6 @@ def tsboot(data, statistic, R, l):
     print(  "="*25  )
     print(  "Runtime: %g sec" % (time()-t0))
     print(  "Bootstrap statistics: ")
-    #print(  "original   bias    std.error")
-    #print(  "%7g    %4g %8g" % (statistic(data), \
-    #            np.mean(t) - statistic(data), \
-    #            np.std(t)   ))
     print(  "Original set:      ", statistic(data)  )
     print(  "mean statistics:   ", np.mean(t)   )
     print(  "bias:              ", np.mean(t) - statistic(data) )
@@ -45,10 +45,36 @@ def stat(data):
     return np.mean(data)
 
 
-infile = open(data_path("energies.csv"), "r")
-
 #read in data
-X = np.genfromtxt(infile, delimiter=";")
+infile = open(data_path("energies.csv"), "r")
+csv_reader = csv.reader(infile, delimiter=";")
+for row in csv_reader:
+    X = np.array(row, dtype=float)
+    #t = tsboot(X, stat, int(len(X)*.5), int(len(X)*.2))
+    t = tsboot(X, stat, 2**12, 2**10)
+    #TODO justify numbers used for number of and size of 
+    #       bootstraps
+    """
+    histogram of bootstrapped data:
+    norm=1/True is deprecated and threw an error.
+    updating with 'density' solved it.
+    """
+    n, binsboot, patches = plt.hist(t, 50, density=1, facecolor='red', alpha=.75)
+    """
+    'best fit'
+    mpl.normpdf is deprecated/removed. scipy steps up
+    """
+    y = norm.pdf(binsboot, np.mean(t), np.std(t))
+    lt = plt.plot(binsboot, y, 'r--', linewidth=1)
+    plt.xlabel('mean energy')
+    plt.ylabel('Probability')
+    plt.grid(True)
+    plt.show()
+    break
+    """
+    The program goes per row in the energies file. I'm unsure which variables go
+    to which line and running over each takes a little while. I've also not found
+    a great measure of the number of bootstraps and the amount that ought be sampled
+    per bootstrap, but this seems to give a pretty good result so far. 
+    """
 
-#t = tsboot(X, stat, 2**12, 2**10)
-t = tsboot(X, stat, np.shape(X)[0], 2**10)

--- a/sampler.cpp
+++ b/sampler.cpp
@@ -47,7 +47,7 @@ void Sampler::sample(bool acceptedStep) {
     //for steepest descent
     double derPsi = m_system->getWaveFunction()->computeDerivative(m_system->getParticles()); //the derivative of psi
     m_deltaPsi += derPsi;
-    m_derivativePsiE += derPsi*localEnergy;
+    m_derivativePsiE += derPsi*localEnergy; // Psi' * E_L
 
     m_energies.push_back(localEnergy);
 

--- a/ses.vim
+++ b/ses.vim
@@ -1,0 +1,92 @@
+let SessionLoad = 1
+let s:so_save = &so | let s:siso_save = &siso | set so=0 siso=0
+let v:this_session=expand("<sfile>:p")
+silent only
+cd ~/uni/fys4411/project1/src
+if expand('%') == '' && !&modified && line('$') <= 1 && getline(1) == ''
+  let s:wipebuf = bufnr('%')
+endif
+set shortmess=aoO
+badd +1 Hamiltonians/hamiltonian.h
+badd +0 Hamiltonians/harmonicoscillator.h
+badd +0 InitialStates/initialstate.h
+badd +0 InitialStates/randomuniform.h
+badd +0 Math/random.h
+badd +0 particle.h
+badd +16 sampler.h
+badd +1 system.h
+badd +0 WaveFunctions/simplegaussian.h
+badd +0 WaveFunctions/wavefunction.h
+badd +0 Hamiltonians/hamiltonian.cpp
+badd +0 Hamiltonians/harmonicoscillator.cpp
+badd +0 InitialStates/initialstate.cpp
+badd +0 InitialStates/randomuniform.cpp
+badd +110 main.cpp
+badd +0 particle.cpp
+badd +34 sampler.cpp
+badd +121 system.cpp
+badd +0 WaveFunctions/simplegaussian.cpp
+badd +1 WaveFunctions/wavefunction.cpp
+argglobal
+%argdel
+$argadd Hamiltonians/hamiltonian.h
+$argadd Hamiltonians/harmonicoscillator.h
+$argadd InitialStates/initialstate.h
+$argadd InitialStates/randomuniform.h
+$argadd Math/random.h
+$argadd particle.h
+$argadd sampler.h
+$argadd system.h
+$argadd WaveFunctions/simplegaussian.h
+$argadd WaveFunctions/wavefunction.h
+$argadd build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp
+$argadd Hamiltonians/hamiltonian.cpp
+$argadd Hamiltonians/harmonicoscillator.cpp
+$argadd InitialStates/initialstate.cpp
+$argadd InitialStates/randomuniform.cpp
+$argadd main.cpp
+$argadd particle.cpp
+$argadd sampler.cpp
+$argadd system.cpp
+$argadd WaveFunctions/simplegaussian.cpp
+$argadd WaveFunctions/wavefunction.cpp
+edit WaveFunctions/simplegaussian.cpp
+set splitbelow splitright
+set nosplitbelow
+set nosplitright
+wincmd t
+set winminheight=0
+set winheight=1
+set winminwidth=0
+set winwidth=1
+argglobal
+if bufexists("WaveFunctions/simplegaussian.cpp") | buffer WaveFunctions/simplegaussian.cpp | else | edit WaveFunctions/simplegaussian.cpp | endif
+setlocal fdm=manual
+setlocal fde=0
+setlocal fmr={{{,}}}
+setlocal fdi=#
+setlocal fdl=0
+setlocal fml=1
+setlocal fdn=20
+setlocal fen
+silent! normal! zE
+let s:l = 1 - ((0 * winheight(0) + 22) / 45)
+if s:l < 1 | let s:l = 1 | endif
+exe s:l
+normal! zt
+1
+normal! 0
+tabnext 1
+if exists('s:wipebuf') && getbufvar(s:wipebuf, '&buftype') isnot# 'terminal'
+  silent exe 'bwipe ' . s:wipebuf
+endif
+unlet! s:wipebuf
+set winheight=1 winwidth=20 winminheight=1 winminwidth=1 shortmess=filnxtToOF
+let s:sx = expand("<sfile>:p:r")."x.vim"
+if file_readable(s:sx)
+  exe "source " . fnameescape(s:sx)
+endif
+let &so = s:so_save | let &siso = s:siso_save
+doautoall SessionLoadPost
+unlet SessionLoad
+" vim: set ft=vim :

--- a/tags
+++ b/tags
@@ -16,192 +16,206 @@ $(VERBOSE)MAKESILENT	build/Makefile	/^$(VERBOSE)MAKESILENT = -s$/;"	m
 %	build/Makefile	/^% : RCS\/%,v$/;"	t
 %	build/Makefile	/^% : SCCS\/s.%$/;"	t
 %	build/Makefile	/^% : s.%$/;"	t
-AM	Math/random.h	/^#define AM /;"	d
-ARCHITECTURE_ID	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#   define ARCHITECTURE_ID /;"	d	file:
-ARCHITECTURE_ID	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#  define ARCHITECTURE_ID /;"	d	file:
-ARCHITECTURE_ID	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#  define ARCHITECTURE_ID$/;"	d	file:
-ARCHITECTURE_ID	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#   define ARCHITECTURE_ID /;"	d	file:
-ARCHITECTURE_ID	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define ARCHITECTURE_ID /;"	d	file:
-ARCHITECTURE_ID	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define ARCHITECTURE_ID$/;"	d	file:
-CMAKE_AR	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_AR "\/usr\/bin\/ar")$/;"	v
-CMAKE_AR	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_AR "\/usr\/bin\/ar")$/;"	v
+*.tcc	.vscode/settings.json	/^        "*.tcc": "cpp",$/;"	s	object:files.associations
+0	.vscode/c_cpp_properties.json	/^                "${workspaceFolder}\/**"$/;"	s	array:configurations.0.includePath
+0	.vscode/c_cpp_properties.json	/^                "_DEBUG",$/;"	s	array:configurations.0.defines
+0	.vscode/c_cpp_properties.json	/^        {$/;"	o	array:configurations
+1	.vscode/c_cpp_properties.json	/^                "UNICODE",$/;"	s	array:configurations.0.defines
+2	.vscode/c_cpp_properties.json	/^                "_UNICODE"$/;"	s	array:configurations.0.defines
+ARCHITECTURE_ID	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#   define ARCHITECTURE_ID /;"	d	file:
+ARCHITECTURE_ID	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#  define ARCHITECTURE_ID /;"	d	file:
+ARCHITECTURE_ID	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#  define ARCHITECTURE_ID$/;"	d	file:
+ARCHITECTURE_ID	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#   define ARCHITECTURE_ID /;"	d	file:
+ARCHITECTURE_ID	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define ARCHITECTURE_ID /;"	d	file:
+ARCHITECTURE_ID	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define ARCHITECTURE_ID$/;"	d	file:
+CMAKE_AR	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_AR "\/usr\/bin\/ar")$/;"	v
+CMAKE_AR	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_AR "\/usr\/bin\/ar")$/;"	v
 CMAKE_BINARY_DIR	build/Makefile	/^CMAKE_BINARY_DIR = \/home\/ms\/uni\/fys4411\/project1\/src\/build$/;"	m
-CMAKE_C11_COMPILE_FEATURES	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C11_COMPILE_FEATURES "c_std_11;c_static_assert")$/;"	v
-CMAKE_C90_COMPILE_FEATURES	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C90_COMPILE_FEATURES "c_std_90;c_function_prototypes")$/;"	v
-CMAKE_C99_COMPILE_FEATURES	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C99_COMPILE_FEATURES "c_std_99;c_restrict;c_variadic_macros")$/;"	v
-CMAKE_CL_SHOWINCLUDES_PREFIX	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^  set(CMAKE_CL_SHOWINCLUDES_PREFIX "${CMAKE_C_CL_SHOWINCLUDES_PREFIX}")$/;"	v
-CMAKE_CL_SHOWINCLUDES_PREFIX	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^  set(CMAKE_CL_SHOWINCLUDES_PREFIX "${CMAKE_CXX_CL_SHOWINCLUDES_PREFIX}")$/;"	v
+CMAKE_BUILD_TYPE	CMakeLists.txt	/^  set(CMAKE_BUILD_TYPE Debug)$/;"	v
+CMAKE_C11_COMPILE_FEATURES	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C11_COMPILE_FEATURES "c_std_11;c_static_assert")$/;"	v
+CMAKE_C90_COMPILE_FEATURES	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C90_COMPILE_FEATURES "c_std_90;c_function_prototypes")$/;"	v
+CMAKE_C99_COMPILE_FEATURES	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C99_COMPILE_FEATURES "c_std_99;c_restrict;c_variadic_macros")$/;"	v
+CMAKE_CL_SHOWINCLUDES_PREFIX	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^  set(CMAKE_CL_SHOWINCLUDES_PREFIX "${CMAKE_C_CL_SHOWINCLUDES_PREFIX}")$/;"	v
+CMAKE_CL_SHOWINCLUDES_PREFIX	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^  set(CMAKE_CL_SHOWINCLUDES_PREFIX "${CMAKE_CXX_CL_SHOWINCLUDES_PREFIX}")$/;"	v
 CMAKE_COMMAND	build/Makefile	/^CMAKE_COMMAND = \/usr\/bin\/cmake$/;"	m
-CMAKE_COMPILER_IS_CYGWIN	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_COMPILER_IS_CYGWIN )$/;"	v
-CMAKE_COMPILER_IS_CYGWIN	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_COMPILER_IS_CYGWIN )$/;"	v
-CMAKE_COMPILER_IS_GNUCC	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_COMPILER_IS_GNUCC 1)$/;"	v
-CMAKE_COMPILER_IS_GNUCXX	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_COMPILER_IS_GNUCXX 1)$/;"	v
-CMAKE_COMPILER_IS_MINGW	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_COMPILER_IS_MINGW )$/;"	v
-CMAKE_COMPILER_IS_MINGW	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_COMPILER_IS_MINGW )$/;"	v
-CMAKE_CROSSCOMPILING	build/CMakeFiles/3.19.3/CMakeSystem.cmake	/^set(CMAKE_CROSSCOMPILING "FALSE")$/;"	v
+CMAKE_COMPILER_IS_CYGWIN	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_COMPILER_IS_CYGWIN )$/;"	v
+CMAKE_COMPILER_IS_CYGWIN	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_COMPILER_IS_CYGWIN )$/;"	v
+CMAKE_COMPILER_IS_GNUCC	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_COMPILER_IS_GNUCC 1)$/;"	v
+CMAKE_COMPILER_IS_GNUCXX	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_COMPILER_IS_GNUCXX 1)$/;"	v
+CMAKE_COMPILER_IS_MINGW	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_COMPILER_IS_MINGW )$/;"	v
+CMAKE_COMPILER_IS_MINGW	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_COMPILER_IS_MINGW )$/;"	v
+CMAKE_CROSSCOMPILING	build/CMakeFiles/3.20.0/CMakeSystem.cmake	/^set(CMAKE_CROSSCOMPILING "FALSE")$/;"	v
 CMAKE_CROSSCOMPILING	build/cmake_install.cmake	/^  set(CMAKE_CROSSCOMPILING "FALSE")$/;"	v
-CMAKE_CXX11_COMPILE_FEATURES	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX11_COMPILE_FEATURES "cxx_std_11;cxx_alias_templates;cxx_alignas;cxx_alignof;cxx_att/;"	v
-CMAKE_CXX14_COMPILE_FEATURES	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX14_COMPILE_FEATURES "cxx_std_14;cxx_aggregate_default_initializers;cxx_attribute_de/;"	v
-CMAKE_CXX17_COMPILE_FEATURES	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX17_COMPILE_FEATURES "cxx_std_17")$/;"	v
-CMAKE_CXX20_COMPILE_FEATURES	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX20_COMPILE_FEATURES "cxx_std_20")$/;"	v
-CMAKE_CXX98_COMPILE_FEATURES	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX98_COMPILE_FEATURES "cxx_std_98;cxx_template_template_parameters")$/;"	v
-CMAKE_CXX_ABI_COMPILED	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_ABI_COMPILED TRUE)$/;"	v
-CMAKE_CXX_CL_SHOWINCLUDES_PREFIX	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_CL_SHOWINCLUDES_PREFIX "")$/;"	v
-CMAKE_CXX_COMPILER	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER "\/usr\/bin\/c++")$/;"	v
-CMAKE_CXX_COMPILER_ABI	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_ABI "ELF")$/;"	v
-CMAKE_CXX_COMPILER_AR	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_AR "\/usr\/bin\/gcc-ar")$/;"	v
-CMAKE_CXX_COMPILER_ARG1	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_ARG1 "")$/;"	v
-CMAKE_CXX_COMPILER_ENV_VAR	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_ENV_VAR "CXX")$/;"	v
-CMAKE_CXX_COMPILER_FRONTEND_VARIANT	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_FRONTEND_VARIANT "")$/;"	v
-CMAKE_CXX_COMPILER_ID	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_ID "GNU")$/;"	v
-CMAKE_CXX_COMPILER_ID	build/CMakeFiles/vmc.dir/DependInfo.cmake	/^set(CMAKE_CXX_COMPILER_ID "GNU")$/;"	v
-CMAKE_CXX_COMPILER_ID_RUN	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_ID_RUN 1)$/;"	v
-CMAKE_CXX_COMPILER_LOADED	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_LOADED 1)$/;"	v
-CMAKE_CXX_COMPILER_RANLIB	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_RANLIB "\/usr\/bin\/gcc-ranlib")$/;"	v
-CMAKE_CXX_COMPILER_VERSION	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_VERSION "10.2.0")$/;"	v
-CMAKE_CXX_COMPILER_VERSION_INTERNAL	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_VERSION_INTERNAL "")$/;"	v
-CMAKE_CXX_COMPILER_WORKS	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_WORKS TRUE)$/;"	v
-CMAKE_CXX_COMPILER_WRAPPER	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_WRAPPER "")$/;"	v
-CMAKE_CXX_COMPILE_FEATURES	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILE_FEATURES "cxx_std_98;cxx_template_template_parameters;cxx_std_11;cxx_alias/;"	v
-CMAKE_CXX_IGNORE_EXTENSIONS	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_IGNORE_EXTENSIONS inl;h;hpp;HPP;H;o;O;obj;OBJ;def;DEF;rc;RC)$/;"	v
-CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES "\/usr\/include\/c++\/10.2.0;\/usr\/include\/c++\/10./;"	v
-CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES "\/usr\/lib\/gcc\/x86_64-pc-linux-gnu\/10.2.0;\/usr\/lib/;"	v
-CMAKE_CXX_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES "")$/;"	v
-CMAKE_CXX_IMPLICIT_LINK_LIBRARIES	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_IMPLICIT_LINK_LIBRARIES "stdc++;m;gcc_s;gcc;c;gcc_s;gcc")$/;"	v
+CMAKE_CXX11_COMPILE_FEATURES	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX11_COMPILE_FEATURES "cxx_std_11;cxx_alias_templates;cxx_alignas;cxx_alignof;cxx_att/;"	v
+CMAKE_CXX14_COMPILE_FEATURES	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX14_COMPILE_FEATURES "cxx_std_14;cxx_aggregate_default_initializers;cxx_attribute_de/;"	v
+CMAKE_CXX17_COMPILE_FEATURES	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX17_COMPILE_FEATURES "cxx_std_17")$/;"	v
+CMAKE_CXX20_COMPILE_FEATURES	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX20_COMPILE_FEATURES "cxx_std_20")$/;"	v
+CMAKE_CXX23_COMPILE_FEATURES	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX23_COMPILE_FEATURES "")$/;"	v
+CMAKE_CXX98_COMPILE_FEATURES	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX98_COMPILE_FEATURES "cxx_std_98;cxx_template_template_parameters")$/;"	v
+CMAKE_CXX_ABI_COMPILED	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_ABI_COMPILED TRUE)$/;"	v
+CMAKE_CXX_BYTE_ORDER	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_BYTE_ORDER "LITTLE_ENDIAN")$/;"	v
+CMAKE_CXX_CL_SHOWINCLUDES_PREFIX	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_CL_SHOWINCLUDES_PREFIX "")$/;"	v
+CMAKE_CXX_COMPILER	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER "\/usr\/bin\/c++")$/;"	v
+CMAKE_CXX_COMPILER_ABI	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_ABI "ELF")$/;"	v
+CMAKE_CXX_COMPILER_AR	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_AR "\/usr\/bin\/gcc-ar")$/;"	v
+CMAKE_CXX_COMPILER_ARG1	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_ARG1 "")$/;"	v
+CMAKE_CXX_COMPILER_ENV_VAR	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_ENV_VAR "CXX")$/;"	v
+CMAKE_CXX_COMPILER_FRONTEND_VARIANT	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_FRONTEND_VARIANT "")$/;"	v
+CMAKE_CXX_COMPILER_ID	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_ID "GNU")$/;"	v
+CMAKE_CXX_COMPILER_ID_RUN	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_ID_RUN 1)$/;"	v
+CMAKE_CXX_COMPILER_LOADED	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_LOADED 1)$/;"	v
+CMAKE_CXX_COMPILER_RANLIB	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_RANLIB "\/usr\/bin\/gcc-ranlib")$/;"	v
+CMAKE_CXX_COMPILER_VERSION	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_VERSION "10.2.0")$/;"	v
+CMAKE_CXX_COMPILER_VERSION_INTERNAL	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_VERSION_INTERNAL "")$/;"	v
+CMAKE_CXX_COMPILER_WORKS	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_WORKS TRUE)$/;"	v
+CMAKE_CXX_COMPILER_WRAPPER	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILER_WRAPPER "")$/;"	v
+CMAKE_CXX_COMPILE_FEATURES	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_COMPILE_FEATURES "cxx_std_98;cxx_template_template_parameters;cxx_std_11;cxx_alias/;"	v
+CMAKE_CXX_FLAGS	CMakeLists.txt	/^set(CMAKE_CXX_FLAGS "-Wall -Wextra")$/;"	v
+CMAKE_CXX_FLAGS_DEBUG	CMakeLists.txt	/^set(CMAKE_CXX_FLAGS_DEBUG "-g")$/;"	v
+CMAKE_CXX_FLAGS_RELEASE	CMakeLists.txt	/^set(CMAKE_CXX_FLAGS_RELEASE "-O3")$/;"	v
+CMAKE_CXX_IGNORE_EXTENSIONS	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_IGNORE_EXTENSIONS inl;h;hpp;HPP;H;o;O;obj;OBJ;def;DEF;rc;RC)$/;"	v
+CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES "\/usr\/include\/c++\/10.2.0;\/usr\/include\/c++\/10./;"	v
+CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES "\/usr\/lib\/gcc\/x86_64-pc-linux-gnu\/10.2.0;\/usr\/lib/;"	v
+CMAKE_CXX_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES "")$/;"	v
+CMAKE_CXX_IMPLICIT_LINK_LIBRARIES	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_IMPLICIT_LINK_LIBRARIES "stdc++;m;gcc_s;gcc;c;gcc_s;gcc")$/;"	v
 CMAKE_CXX_INCLUDE_REGEX_COMPLAIN	build/CMakeFiles/CMakeDirectoryInformation.cmake	/^set(CMAKE_CXX_INCLUDE_REGEX_COMPLAIN ${CMAKE_C_INCLUDE_REGEX_COMPLAIN})$/;"	v
 CMAKE_CXX_INCLUDE_REGEX_SCAN	build/CMakeFiles/CMakeDirectoryInformation.cmake	/^set(CMAKE_CXX_INCLUDE_REGEX_SCAN ${CMAKE_C_INCLUDE_REGEX_SCAN})$/;"	v
-CMAKE_CXX_LIBRARY_ARCHITECTURE	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_LIBRARY_ARCHITECTURE "")$/;"	v
-CMAKE_CXX_LINKER_PREFERENCE	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_LINKER_PREFERENCE 30)$/;"	v
-CMAKE_CXX_LINKER_PREFERENCE_PROPAGATES	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_LINKER_PREFERENCE_PROPAGATES 1)$/;"	v
-CMAKE_CXX_PLATFORM_ID	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_PLATFORM_ID "Linux")$/;"	v
-CMAKE_CXX_SIMULATE_ID	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_SIMULATE_ID "")$/;"	v
-CMAKE_CXX_SIMULATE_VERSION	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_SIMULATE_VERSION "")$/;"	v
-CMAKE_CXX_SIZEOF_DATA_PTR	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_SIZEOF_DATA_PTR "8")$/;"	v
-CMAKE_CXX_SOURCE_FILE_EXTENSIONS	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_SOURCE_FILE_EXTENSIONS C;M;c++;cc;cpp;cxx;m;mm;CPP)$/;"	v
-CMAKE_CXX_STANDARD_COMPUTED_DEFAULT	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_STANDARD_COMPUTED_DEFAULT "14")$/;"	v
-CMAKE_CXX_TARGET_INCLUDE_PATH	build/CMakeFiles/vmc.dir/DependInfo.cmake	/^set(CMAKE_CXX_TARGET_INCLUDE_PATH$/;"	v
-CMAKE_C_ABI_COMPILED	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_ABI_COMPILED TRUE)$/;"	v
-CMAKE_C_CL_SHOWINCLUDES_PREFIX	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_CL_SHOWINCLUDES_PREFIX "")$/;"	v
-CMAKE_C_COMPILER	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER "\/usr\/bin\/cc")$/;"	v
-CMAKE_C_COMPILER_ABI	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_ABI "ELF")$/;"	v
-CMAKE_C_COMPILER_AR	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_AR "\/usr\/bin\/gcc-ar")$/;"	v
-CMAKE_C_COMPILER_ARG1	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_ARG1 "")$/;"	v
-CMAKE_C_COMPILER_ENV_VAR	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_ENV_VAR "CC")$/;"	v
-CMAKE_C_COMPILER_FRONTEND_VARIANT	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_FRONTEND_VARIANT "")$/;"	v
-CMAKE_C_COMPILER_ID	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_ID "GNU")$/;"	v
-CMAKE_C_COMPILER_ID_RUN	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_ID_RUN 1)$/;"	v
-CMAKE_C_COMPILER_LOADED	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_LOADED 1)$/;"	v
-CMAKE_C_COMPILER_RANLIB	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_RANLIB "\/usr\/bin\/gcc-ranlib")$/;"	v
-CMAKE_C_COMPILER_VERSION	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_VERSION "10.2.0")$/;"	v
-CMAKE_C_COMPILER_VERSION_INTERNAL	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_VERSION_INTERNAL "")$/;"	v
-CMAKE_C_COMPILER_WORKS	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_WORKS TRUE)$/;"	v
-CMAKE_C_COMPILER_WRAPPER	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_WRAPPER "")$/;"	v
-CMAKE_C_COMPILE_FEATURES	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILE_FEATURES "c_std_90;c_function_prototypes;c_std_99;c_restrict;c_variadic_macr/;"	v
-CMAKE_C_IGNORE_EXTENSIONS	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_IGNORE_EXTENSIONS h;H;o;O;obj;OBJ;def;DEF;rc;RC)$/;"	v
-CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES "\/usr\/lib\/gcc\/x86_64-pc-linux-gnu\/10.2.0\/include;/;"	v
-CMAKE_C_IMPLICIT_LINK_DIRECTORIES	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_IMPLICIT_LINK_DIRECTORIES "\/usr\/lib\/gcc\/x86_64-pc-linux-gnu\/10.2.0;\/usr\/lib;\//;"	v
-CMAKE_C_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES "")$/;"	v
-CMAKE_C_IMPLICIT_LINK_LIBRARIES	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_IMPLICIT_LINK_LIBRARIES "gcc;gcc_s;c;gcc;gcc_s")$/;"	v
+CMAKE_CXX_LIBRARY_ARCHITECTURE	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_LIBRARY_ARCHITECTURE "x86_64-pc-linux-gnu")$/;"	v
+CMAKE_CXX_LINKER_PREFERENCE	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_LINKER_PREFERENCE 30)$/;"	v
+CMAKE_CXX_LINKER_PREFERENCE_PROPAGATES	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_LINKER_PREFERENCE_PROPAGATES 1)$/;"	v
+CMAKE_CXX_PLATFORM_ID	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_PLATFORM_ID "Linux")$/;"	v
+CMAKE_CXX_SIMULATE_ID	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_SIMULATE_ID "")$/;"	v
+CMAKE_CXX_SIMULATE_VERSION	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_SIMULATE_VERSION "")$/;"	v
+CMAKE_CXX_SIZEOF_DATA_PTR	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_SIZEOF_DATA_PTR "8")$/;"	v
+CMAKE_CXX_SOURCE_FILE_EXTENSIONS	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_SOURCE_FILE_EXTENSIONS C;M;c++;cc;cpp;cxx;m;mm;mpp;CPP)$/;"	v
+CMAKE_CXX_STANDARD	CMakeLists.txt	/^set(CMAKE_CXX_STANDARD 17)$/;"	v
+CMAKE_CXX_STANDARD_COMPUTED_DEFAULT	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_CXX_STANDARD_COMPUTED_DEFAULT "14")$/;"	v
+CMAKE_C_ABI_COMPILED	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_ABI_COMPILED TRUE)$/;"	v
+CMAKE_C_BYTE_ORDER	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_BYTE_ORDER "LITTLE_ENDIAN")$/;"	v
+CMAKE_C_CL_SHOWINCLUDES_PREFIX	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_CL_SHOWINCLUDES_PREFIX "")$/;"	v
+CMAKE_C_COMPILER	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER "\/usr\/bin\/cc")$/;"	v
+CMAKE_C_COMPILER_ABI	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_ABI "ELF")$/;"	v
+CMAKE_C_COMPILER_AR	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_AR "\/usr\/bin\/gcc-ar")$/;"	v
+CMAKE_C_COMPILER_ARG1	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_ARG1 "")$/;"	v
+CMAKE_C_COMPILER_ENV_VAR	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_ENV_VAR "CC")$/;"	v
+CMAKE_C_COMPILER_FRONTEND_VARIANT	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_FRONTEND_VARIANT "")$/;"	v
+CMAKE_C_COMPILER_ID	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_ID "GNU")$/;"	v
+CMAKE_C_COMPILER_ID_RUN	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_ID_RUN 1)$/;"	v
+CMAKE_C_COMPILER_LOADED	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_LOADED 1)$/;"	v
+CMAKE_C_COMPILER_RANLIB	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_RANLIB "\/usr\/bin\/gcc-ranlib")$/;"	v
+CMAKE_C_COMPILER_VERSION	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_VERSION "10.2.0")$/;"	v
+CMAKE_C_COMPILER_VERSION_INTERNAL	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_VERSION_INTERNAL "")$/;"	v
+CMAKE_C_COMPILER_WORKS	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_WORKS TRUE)$/;"	v
+CMAKE_C_COMPILER_WRAPPER	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILER_WRAPPER "")$/;"	v
+CMAKE_C_COMPILE_FEATURES	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_COMPILE_FEATURES "c_std_90;c_function_prototypes;c_std_99;c_restrict;c_variadic_macr/;"	v
+CMAKE_C_IGNORE_EXTENSIONS	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_IGNORE_EXTENSIONS h;H;o;O;obj;OBJ;def;DEF;rc;RC)$/;"	v
+CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES "\/usr\/lib\/gcc\/x86_64-pc-linux-gnu\/10.2.0\/include;/;"	v
+CMAKE_C_IMPLICIT_LINK_DIRECTORIES	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_IMPLICIT_LINK_DIRECTORIES "\/usr\/lib\/gcc\/x86_64-pc-linux-gnu\/10.2.0;\/usr\/lib;\//;"	v
+CMAKE_C_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES "")$/;"	v
+CMAKE_C_IMPLICIT_LINK_LIBRARIES	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_IMPLICIT_LINK_LIBRARIES "gcc;gcc_s;c;gcc;gcc_s")$/;"	v
 CMAKE_C_INCLUDE_REGEX_COMPLAIN	build/CMakeFiles/CMakeDirectoryInformation.cmake	/^set(CMAKE_C_INCLUDE_REGEX_COMPLAIN "^$")$/;"	v
 CMAKE_C_INCLUDE_REGEX_SCAN	build/CMakeFiles/CMakeDirectoryInformation.cmake	/^set(CMAKE_C_INCLUDE_REGEX_SCAN "^.*$")$/;"	v
-CMAKE_C_LIBRARY_ARCHITECTURE	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_LIBRARY_ARCHITECTURE "")$/;"	v
-CMAKE_C_LINKER_PREFERENCE	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_LINKER_PREFERENCE 10)$/;"	v
-CMAKE_C_PLATFORM_ID	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_PLATFORM_ID "Linux")$/;"	v
-CMAKE_C_SIMULATE_ID	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_SIMULATE_ID "")$/;"	v
-CMAKE_C_SIMULATE_VERSION	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_SIMULATE_VERSION "")$/;"	v
-CMAKE_C_SIZEOF_DATA_PTR	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_SIZEOF_DATA_PTR "8")$/;"	v
-CMAKE_C_SOURCE_FILE_EXTENSIONS	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_SOURCE_FILE_EXTENSIONS c;m)$/;"	v
-CMAKE_C_STANDARD_COMPUTED_DEFAULT	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_C_STANDARD_COMPUTED_DEFAULT "11")$/;"	v
-CMAKE_DEPENDS_CHECK_CXX	build/CMakeFiles/vmc.dir/DependInfo.cmake	/^set(CMAKE_DEPENDS_CHECK_CXX$/;"	v
+CMAKE_C_LIBRARY_ARCHITECTURE	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_LIBRARY_ARCHITECTURE "x86_64-pc-linux-gnu")$/;"	v
+CMAKE_C_LINKER_PREFERENCE	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_LINKER_PREFERENCE 10)$/;"	v
+CMAKE_C_PLATFORM_ID	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_PLATFORM_ID "Linux")$/;"	v
+CMAKE_C_SIMULATE_ID	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_SIMULATE_ID "")$/;"	v
+CMAKE_C_SIMULATE_VERSION	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_SIMULATE_VERSION "")$/;"	v
+CMAKE_C_SIZEOF_DATA_PTR	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_SIZEOF_DATA_PTR "8")$/;"	v
+CMAKE_C_SOURCE_FILE_EXTENSIONS	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_SOURCE_FILE_EXTENSIONS c;m)$/;"	v
+CMAKE_C_STANDARD_COMPUTED_DEFAULT	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_C_STANDARD_COMPUTED_DEFAULT "11")$/;"	v
+CMAKE_DEPENDS_DEPENDENCY_FILES	build/CMakeFiles/vmc.dir/DependInfo.cmake	/^set(CMAKE_DEPENDS_DEPENDENCY_FILES$/;"	v
 CMAKE_DEPENDS_GENERATOR	build/CMakeFiles/Makefile.cmake	/^set(CMAKE_DEPENDS_GENERATOR "Unix Makefiles")$/;"	v
+CMAKE_DEPENDS_IN_PROJECT_ONLY	build/CMakeFiles/vmc.dir/DependInfo.cmake	/^set(CMAKE_DEPENDS_IN_PROJECT_ONLY OFF)$/;"	v
 CMAKE_DEPENDS_LANGUAGES	build/CMakeFiles/vmc.dir/DependInfo.cmake	/^set(CMAKE_DEPENDS_LANGUAGES$/;"	v
 CMAKE_DEPEND_INFO_FILES	build/CMakeFiles/Makefile.cmake	/^set(CMAKE_DEPEND_INFO_FILES$/;"	v
 CMAKE_FORCE_UNIX_PATHS	build/CMakeFiles/CMakeDirectoryInformation.cmake	/^set(CMAKE_FORCE_UNIX_PATHS 1)$/;"	v
 CMAKE_Fortran_TARGET_MODULE_DIR	build/CMakeFiles/vmc.dir/DependInfo.cmake	/^set(CMAKE_Fortran_TARGET_MODULE_DIR "")$/;"	v
-CMAKE_HOST_SYSTEM	build/CMakeFiles/3.19.3/CMakeSystem.cmake	/^set(CMAKE_HOST_SYSTEM "Linux-5.10.9-arch1-1")$/;"	v
-CMAKE_HOST_SYSTEM_NAME	build/CMakeFiles/3.19.3/CMakeSystem.cmake	/^set(CMAKE_HOST_SYSTEM_NAME "Linux")$/;"	v
-CMAKE_HOST_SYSTEM_PROCESSOR	build/CMakeFiles/3.19.3/CMakeSystem.cmake	/^set(CMAKE_HOST_SYSTEM_PROCESSOR "x86_64")$/;"	v
-CMAKE_HOST_SYSTEM_VERSION	build/CMakeFiles/3.19.3/CMakeSystem.cmake	/^set(CMAKE_HOST_SYSTEM_VERSION "5.10.9-arch1-1")$/;"	v
+CMAKE_HOST_SYSTEM	build/CMakeFiles/3.20.0/CMakeSystem.cmake	/^set(CMAKE_HOST_SYSTEM "Linux-5.11.8-arch1-1")$/;"	v
+CMAKE_HOST_SYSTEM_NAME	build/CMakeFiles/3.20.0/CMakeSystem.cmake	/^set(CMAKE_HOST_SYSTEM_NAME "Linux")$/;"	v
+CMAKE_HOST_SYSTEM_PROCESSOR	build/CMakeFiles/3.20.0/CMakeSystem.cmake	/^set(CMAKE_HOST_SYSTEM_PROCESSOR "x86_64")$/;"	v
+CMAKE_HOST_SYSTEM_VERSION	build/CMakeFiles/3.20.0/CMakeSystem.cmake	/^set(CMAKE_HOST_SYSTEM_VERSION "5.11.8-arch1-1")$/;"	v
 CMAKE_INSTALL_COMPONENT	build/cmake_install.cmake	/^    set(CMAKE_INSTALL_COMPONENT "${COMPONENT}")$/;"	v
 CMAKE_INSTALL_COMPONENT	build/cmake_install.cmake	/^    set(CMAKE_INSTALL_COMPONENT)$/;"	v
-CMAKE_INSTALL_CONFIG_NAME	build/cmake_install.cmake	/^    set(CMAKE_INSTALL_CONFIG_NAME "")$/;"	v
+CMAKE_INSTALL_CONFIG_NAME	build/cmake_install.cmake	/^    set(CMAKE_INSTALL_CONFIG_NAME "Debug")$/;"	v
 CMAKE_INSTALL_MANIFEST	build/cmake_install.cmake	/^  set(CMAKE_INSTALL_MANIFEST "install_manifest.txt")$/;"	v
 CMAKE_INSTALL_MANIFEST	build/cmake_install.cmake	/^  set(CMAKE_INSTALL_MANIFEST "install_manifest_${CMAKE_INSTALL_COMPONENT}.txt")$/;"	v
 CMAKE_INSTALL_PREFIX	build/cmake_install.cmake	/^  set(CMAKE_INSTALL_PREFIX "\/usr\/local")$/;"	v
 CMAKE_INSTALL_SO_NO_EXE	build/cmake_install.cmake	/^  set(CMAKE_INSTALL_SO_NO_EXE "0")$/;"	v
-CMAKE_INTERNAL_PLATFORM_ABI	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^  set(CMAKE_INTERNAL_PLATFORM_ABI "${CMAKE_C_COMPILER_ABI}")$/;"	v
-CMAKE_INTERNAL_PLATFORM_ABI	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^  set(CMAKE_INTERNAL_PLATFORM_ABI "${CMAKE_CXX_COMPILER_ABI}")$/;"	v
-CMAKE_LIBRARY_ARCHITECTURE	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^  set(CMAKE_LIBRARY_ARCHITECTURE "")$/;"	v
-CMAKE_LIBRARY_ARCHITECTURE	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^  set(CMAKE_LIBRARY_ARCHITECTURE "")$/;"	v
-CMAKE_LINKER	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_LINKER "\/usr\/bin\/ld")$/;"	v
-CMAKE_LINKER	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_LINKER "\/usr\/bin\/ld")$/;"	v
+CMAKE_INTERNAL_PLATFORM_ABI	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^  set(CMAKE_INTERNAL_PLATFORM_ABI "${CMAKE_C_COMPILER_ABI}")$/;"	v
+CMAKE_INTERNAL_PLATFORM_ABI	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^  set(CMAKE_INTERNAL_PLATFORM_ABI "${CMAKE_CXX_COMPILER_ABI}")$/;"	v
+CMAKE_LIBRARY_ARCHITECTURE	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^  set(CMAKE_LIBRARY_ARCHITECTURE "x86_64-pc-linux-gnu")$/;"	v
+CMAKE_LIBRARY_ARCHITECTURE	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^  set(CMAKE_LIBRARY_ARCHITECTURE "x86_64-pc-linux-gnu")$/;"	v
+CMAKE_LINKER	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_LINKER "\/usr\/bin\/ld")$/;"	v
+CMAKE_LINKER	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_LINKER "\/usr\/bin\/ld")$/;"	v
 CMAKE_MAKEFILE_DEPENDS	build/CMakeFiles/Makefile.cmake	/^set(CMAKE_MAKEFILE_DEPENDS$/;"	v
 CMAKE_MAKEFILE_OUTPUTS	build/CMakeFiles/Makefile.cmake	/^set(CMAKE_MAKEFILE_OUTPUTS$/;"	v
 CMAKE_MAKEFILE_PRODUCTS	build/CMakeFiles/Makefile.cmake	/^set(CMAKE_MAKEFILE_PRODUCTS$/;"	v
-CMAKE_MT	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_MT "")$/;"	v
-CMAKE_MT	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_MT "")$/;"	v
+CMAKE_MT	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_MT "")$/;"	v
+CMAKE_MT	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_MT "")$/;"	v
 CMAKE_OBJDUMP	build/cmake_install.cmake	/^  set(CMAKE_OBJDUMP "\/usr\/bin\/objdump")$/;"	v
-CMAKE_RANLIB	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^set(CMAKE_RANLIB "\/usr\/bin\/ranlib")$/;"	v
-CMAKE_RANLIB	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^set(CMAKE_RANLIB "\/usr\/bin\/ranlib")$/;"	v
+CMAKE_RANLIB	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^set(CMAKE_RANLIB "\/usr\/bin\/ranlib")$/;"	v
+CMAKE_RANLIB	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^set(CMAKE_RANLIB "\/usr\/bin\/ranlib")$/;"	v
 CMAKE_RELATIVE_PATH_TOP_BINARY	build/CMakeFiles/CMakeDirectoryInformation.cmake	/^set(CMAKE_RELATIVE_PATH_TOP_BINARY "\/home\/ms\/uni\/fys4411\/project1\/src\/build")$/;"	v
 CMAKE_RELATIVE_PATH_TOP_SOURCE	build/CMakeFiles/CMakeDirectoryInformation.cmake	/^set(CMAKE_RELATIVE_PATH_TOP_SOURCE "\/home\/ms\/uni\/fys4411\/project1\/src")$/;"	v
-CMAKE_SIZEOF_VOID_P	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^  set(CMAKE_SIZEOF_VOID_P "${CMAKE_C_SIZEOF_DATA_PTR}")$/;"	v
-CMAKE_SIZEOF_VOID_P	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^  set(CMAKE_SIZEOF_VOID_P "${CMAKE_CXX_SIZEOF_DATA_PTR}")$/;"	v
+CMAKE_SIZEOF_VOID_P	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^  set(CMAKE_SIZEOF_VOID_P "${CMAKE_C_SIZEOF_DATA_PTR}")$/;"	v
+CMAKE_SIZEOF_VOID_P	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^  set(CMAKE_SIZEOF_VOID_P "${CMAKE_CXX_SIZEOF_DATA_PTR}")$/;"	v
 CMAKE_SOURCE_DIR	build/Makefile	/^CMAKE_SOURCE_DIR = \/home\/ms\/uni\/fys4411\/project1\/src$/;"	m
-CMAKE_SYSTEM	build/CMakeFiles/3.19.3/CMakeSystem.cmake	/^set(CMAKE_SYSTEM "Linux-5.10.9-arch1-1")$/;"	v
-CMAKE_SYSTEM_LOADED	build/CMakeFiles/3.19.3/CMakeSystem.cmake	/^set(CMAKE_SYSTEM_LOADED 1)$/;"	v
-CMAKE_SYSTEM_NAME	build/CMakeFiles/3.19.3/CMakeSystem.cmake	/^set(CMAKE_SYSTEM_NAME "Linux")$/;"	v
-CMAKE_SYSTEM_PROCESSOR	build/CMakeFiles/3.19.3/CMakeSystem.cmake	/^set(CMAKE_SYSTEM_PROCESSOR "x86_64")$/;"	v
-CMAKE_SYSTEM_VERSION	build/CMakeFiles/3.19.3/CMakeSystem.cmake	/^set(CMAKE_SYSTEM_VERSION "5.10.9-arch1-1")$/;"	v
+CMAKE_SYSTEM	build/CMakeFiles/3.20.0/CMakeSystem.cmake	/^set(CMAKE_SYSTEM "Linux-5.11.8-arch1-1")$/;"	v
+CMAKE_SYSTEM_LOADED	build/CMakeFiles/3.20.0/CMakeSystem.cmake	/^set(CMAKE_SYSTEM_LOADED 1)$/;"	v
+CMAKE_SYSTEM_NAME	build/CMakeFiles/3.20.0/CMakeSystem.cmake	/^set(CMAKE_SYSTEM_NAME "Linux")$/;"	v
+CMAKE_SYSTEM_PROCESSOR	build/CMakeFiles/3.20.0/CMakeSystem.cmake	/^set(CMAKE_SYSTEM_PROCESSOR "x86_64")$/;"	v
+CMAKE_SYSTEM_VERSION	build/CMakeFiles/3.20.0/CMakeSystem.cmake	/^set(CMAKE_SYSTEM_VERSION "5.11.8-arch1-1")$/;"	v
 CMAKE_TARGET_LINKED_INFO_FILES	build/CMakeFiles/vmc.dir/DependInfo.cmake	/^set(CMAKE_TARGET_LINKED_INFO_FILES$/;"	v
-COMPILER_ID	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^# define COMPILER_ID /;"	d	file:
-COMPILER_ID	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define COMPILER_ID /;"	d	file:
-COMPILER_VERSION_INTERNAL	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#  define COMPILER_VERSION_INTERNAL /;"	d	file:
-COMPILER_VERSION_INTERNAL	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^# define COMPILER_VERSION_INTERNAL /;"	d	file:
-COMPILER_VERSION_INTERNAL	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define COMPILER_VERSION_INTERNAL /;"	d	file:
-COMPILER_VERSION_INTERNAL	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define COMPILER_VERSION_INTERNAL /;"	d	file:
-COMPILER_VERSION_MAJOR	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^  # define COMPILER_VERSION_MAJOR /;"	d	file:
-COMPILER_VERSION_MAJOR	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#  define COMPILER_VERSION_MAJOR /;"	d	file:
-COMPILER_VERSION_MAJOR	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^# define COMPILER_VERSION_MAJOR /;"	d	file:
-COMPILER_VERSION_MAJOR	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^  # define COMPILER_VERSION_MAJOR /;"	d	file:
-COMPILER_VERSION_MAJOR	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define COMPILER_VERSION_MAJOR /;"	d	file:
-COMPILER_VERSION_MAJOR	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define COMPILER_VERSION_MAJOR /;"	d	file:
-COMPILER_VERSION_MINOR	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^  # define COMPILER_VERSION_MINOR /;"	d	file:
-COMPILER_VERSION_MINOR	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#  define COMPILER_VERSION_MINOR /;"	d	file:
-COMPILER_VERSION_MINOR	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^# define COMPILER_VERSION_MINOR /;"	d	file:
-COMPILER_VERSION_MINOR	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^  # define COMPILER_VERSION_MINOR /;"	d	file:
-COMPILER_VERSION_MINOR	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define COMPILER_VERSION_MINOR /;"	d	file:
-COMPILER_VERSION_MINOR	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define COMPILER_VERSION_MINOR /;"	d	file:
-COMPILER_VERSION_PATCH	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^  # define COMPILER_VERSION_PATCH /;"	d	file:
-COMPILER_VERSION_PATCH	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#   define COMPILER_VERSION_PATCH /;"	d	file:
-COMPILER_VERSION_PATCH	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#  define COMPILER_VERSION_PATCH /;"	d	file:
-COMPILER_VERSION_PATCH	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^# define COMPILER_VERSION_PATCH /;"	d	file:
-COMPILER_VERSION_PATCH	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^  # define COMPILER_VERSION_PATCH /;"	d	file:
-COMPILER_VERSION_PATCH	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#   define COMPILER_VERSION_PATCH /;"	d	file:
-COMPILER_VERSION_PATCH	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define COMPILER_VERSION_PATCH /;"	d	file:
-COMPILER_VERSION_PATCH	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define COMPILER_VERSION_PATCH /;"	d	file:
-COMPILER_VERSION_TWEAK	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#  define COMPILER_VERSION_TWEAK /;"	d	file:
-COMPILER_VERSION_TWEAK	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^# define COMPILER_VERSION_TWEAK /;"	d	file:
-COMPILER_VERSION_TWEAK	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define COMPILER_VERSION_TWEAK /;"	d	file:
-COMPILER_VERSION_TWEAK	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define COMPILER_VERSION_TWEAK /;"	d	file:
-CXX_STD	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#      define CXX_STD /;"	d	file:
-CXX_STD	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#    define CXX_STD /;"	d	file:
-CXX_STD	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define CXX_STD /;"	d	file:
-CYGWIN	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^  set(CYGWIN 1)$/;"	v
-CYGWIN	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^  set(CYGWIN 1)$/;"	v
-C_DIALECT	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#  define C_DIALECT /;"	d	file:
-C_DIALECT	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#  define C_DIALECT$/;"	d	file:
-C_DIALECT	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^# define C_DIALECT /;"	d	file:
-Cleaning the directory	README.md	/^#### Cleaning the directory$/;"	t	subsection:Simple Variational Monte Carlo solve for FYS4411""Compilling and running the project""Compiling the project using CMake
-Compiling the project using CMake	README.md	/^### Compiling the project using CMake$/;"	S	section:Simple Variational Monte Carlo solve for FYS4411""Compilling and running the project
-Compilling and running the project	README.md	/^## Compilling and running the project$/;"	s	chapter:Simple Variational Monte Carlo solve for FYS4411
+COMPILER_ID	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^# define COMPILER_ID /;"	d	file:
+COMPILER_ID	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define COMPILER_ID /;"	d	file:
+COMPILER_VERSION_INTERNAL	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#  define COMPILER_VERSION_INTERNAL /;"	d	file:
+COMPILER_VERSION_INTERNAL	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^# define COMPILER_VERSION_INTERNAL /;"	d	file:
+COMPILER_VERSION_INTERNAL	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define COMPILER_VERSION_INTERNAL /;"	d	file:
+COMPILER_VERSION_INTERNAL	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define COMPILER_VERSION_INTERNAL /;"	d	file:
+COMPILER_VERSION_MAJOR	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^  # define COMPILER_VERSION_MAJOR /;"	d	file:
+COMPILER_VERSION_MAJOR	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#  define COMPILER_VERSION_MAJOR /;"	d	file:
+COMPILER_VERSION_MAJOR	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^# define COMPILER_VERSION_MAJOR /;"	d	file:
+COMPILER_VERSION_MAJOR	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^  # define COMPILER_VERSION_MAJOR /;"	d	file:
+COMPILER_VERSION_MAJOR	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define COMPILER_VERSION_MAJOR /;"	d	file:
+COMPILER_VERSION_MAJOR	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define COMPILER_VERSION_MAJOR /;"	d	file:
+COMPILER_VERSION_MINOR	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^  # define COMPILER_VERSION_MINOR /;"	d	file:
+COMPILER_VERSION_MINOR	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#  define COMPILER_VERSION_MINOR /;"	d	file:
+COMPILER_VERSION_MINOR	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^# define COMPILER_VERSION_MINOR /;"	d	file:
+COMPILER_VERSION_MINOR	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^  # define COMPILER_VERSION_MINOR /;"	d	file:
+COMPILER_VERSION_MINOR	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define COMPILER_VERSION_MINOR /;"	d	file:
+COMPILER_VERSION_MINOR	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define COMPILER_VERSION_MINOR /;"	d	file:
+COMPILER_VERSION_PATCH	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^  # define COMPILER_VERSION_PATCH /;"	d	file:
+COMPILER_VERSION_PATCH	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#   define COMPILER_VERSION_PATCH /;"	d	file:
+COMPILER_VERSION_PATCH	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#  define COMPILER_VERSION_PATCH /;"	d	file:
+COMPILER_VERSION_PATCH	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^# define COMPILER_VERSION_PATCH /;"	d	file:
+COMPILER_VERSION_PATCH	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^  # define COMPILER_VERSION_PATCH /;"	d	file:
+COMPILER_VERSION_PATCH	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#   define COMPILER_VERSION_PATCH /;"	d	file:
+COMPILER_VERSION_PATCH	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define COMPILER_VERSION_PATCH /;"	d	file:
+COMPILER_VERSION_PATCH	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define COMPILER_VERSION_PATCH /;"	d	file:
+COMPILER_VERSION_TWEAK	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#  define COMPILER_VERSION_TWEAK /;"	d	file:
+COMPILER_VERSION_TWEAK	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^# define COMPILER_VERSION_TWEAK /;"	d	file:
+COMPILER_VERSION_TWEAK	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define COMPILER_VERSION_TWEAK /;"	d	file:
+COMPILER_VERSION_TWEAK	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define COMPILER_VERSION_TWEAK /;"	d	file:
+CXX_STD	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#      define CXX_STD /;"	d	file:
+CXX_STD	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#    define CXX_STD /;"	d	file:
+CXX_STD	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define CXX_STD /;"	d	file:
+CYGWIN	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^  set(CYGWIN 1)$/;"	v
+CYGWIN	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^  set(CYGWIN 1)$/;"	v
+C_Cpp.errorSquiggles	.vscode/settings.json	/^    "C_Cpp.errorSquiggles": "Disabled"$/;"	s
+C_DIALECT	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#  define C_DIALECT /;"	d	file:
+C_DIALECT	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#  define C_DIALECT$/;"	d	file:
+C_DIALECT	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^# define C_DIALECT /;"	d	file:
+Cleaning the directory	README.md	/^#### Cleaning the directory$/;"	t	subsection:Simple Variational Monte Carlo solve for FYS4411""Compiling and running the project""Compiling the project using CMake
+Compiling and running the project	README.md	/^## Compiling and running the project$/;"	s	chapter:Simple Variational Monte Carlo solve for FYS4411
+Compiling the project using CMake	README.md	/^### Compiling the project using CMake$/;"	S	section:Simple Variational Monte Carlo solve for FYS4411""Compiling and running the project
 Completing the missing parts	README.md	/^## Completing the missing parts ##$/;"	s	chapter:Simple Variational Monte Carlo solve for FYS4411
-DEC	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#define DEC(/;"	d	file:
-DEC	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#define DEC(/;"	d	file:
-EPS	Math/random.h	/^#define EPS /;"	d
+DATA_ID	resampling.py	/^DATA_ID = "build\/results"$/;"	v
+DEC	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#define DEC(/;"	d	file:
+DEC	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#define DEC(/;"	d	file:
 EQUALS	build/Makefile	/^EQUALS = =$/;"	m
-HEX	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#define HEX(/;"	d	file:
-HEX	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#define HEX(/;"	d	file:
+GreensFunctionRatio	system.cpp	/^double System::GreensFunctionRatio(std::vector<double> posNew, std::vector<double> posOld,$/;"	f	class:System	typeref:typename:double
+HEX	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#define HEX(/;"	d	file:
+HEX	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#define HEX(/;"	d	file:
 Hamiltonian	Hamiltonians/hamiltonian.cpp	/^Hamiltonian::Hamiltonian(System* system) {$/;"	f	class:Hamiltonian
 Hamiltonian	Hamiltonians/hamiltonian.h	/^class Hamiltonian {$/;"	c
 Hamiltonians/hamiltonian.i	build/Makefile	/^Hamiltonians\/hamiltonian.i:$/;"	t
@@ -210,13 +224,9 @@ Hamiltonians/hamiltonian.s	build/Makefile	/^Hamiltonians\/hamiltonian.s:$/;"	t
 Hamiltonians/harmonicoscillator.i	build/Makefile	/^Hamiltonians\/harmonicoscillator.i:$/;"	t
 Hamiltonians/harmonicoscillator.o	build/Makefile	/^Hamiltonians\/harmonicoscillator.o:$/;"	t
 Hamiltonians/harmonicoscillator.s	build/Makefile	/^Hamiltonians\/harmonicoscillator.s:$/;"	t
-HarmonicOscillator	Hamiltonians/harmonicoscillator.cpp	/^HarmonicOscillator::HarmonicOscillator(System* system, double omega) :$/;"	f	class:HarmonicOscillator
+HarmonicOscillator	Hamiltonians/harmonicoscillator.cpp	/^HarmonicOscillator::HarmonicOscillator(System* system, double omega, bool mode) :$/;"	f	class:HarmonicOscillator
 HarmonicOscillator	Hamiltonians/harmonicoscillator.h	/^class HarmonicOscillator : public Hamiltonian {$/;"	c
-IA	Math/random.h	/^#define IA /;"	d
-ID_VOID_MAIN	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^# define ID_VOID_MAIN$/;"	d	file:
-IM	Math/random.h	/^#define IM /;"	d
-IQ	Math/random.h	/^#define IQ /;"	d
-IR	Math/random.h	/^#define IR /;"	d
+ID_VOID_MAIN	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^# define ID_VOID_MAIN$/;"	d	file:
 InitialState	InitialStates/initialstate.cpp	/^InitialState::InitialState(System* system) {$/;"	f	class:InitialState
 InitialState	InitialStates/initialstate.h	/^class InitialState {$/;"	c
 InitialStates/initialstate.i	build/Makefile	/^InitialStates\/initialstate.i:$/;"	t
@@ -225,50 +235,58 @@ InitialStates/initialstate.s	build/Makefile	/^InitialStates\/initialstate.s:$/;"
 InitialStates/randomuniform.i	build/Makefile	/^InitialStates\/randomuniform.i:$/;"	t
 InitialStates/randomuniform.o	build/Makefile	/^InitialStates\/randomuniform.o:$/;"	t
 InitialStates/randomuniform.s	build/Makefile	/^InitialStates\/randomuniform.s:$/;"	t
-MINGW	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^  set(MINGW 1)$/;"	v
-MINGW	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^  set(MINGW 1)$/;"	v
-Math/random.i	build/Makefile	/^Math\/random.i:$/;"	t
-Math/random.o	build/Makefile	/^Math\/random.o:$/;"	t
-Math/random.s	build/Makefile	/^Math\/random.s:$/;"	t
-NDIV	Math/random.h	/^#define NDIV /;"	d
-NTAB	Math/random.h	/^#define NTAB /;"	d
-PLATFORM_ID	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#  define PLATFORM_ID /;"	d	file:
-PLATFORM_ID	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#  define PLATFORM_ID$/;"	d	file:
-PLATFORM_ID	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^# define PLATFORM_ID /;"	d	file:
-PLATFORM_ID	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^# define PLATFORM_ID$/;"	d	file:
-PLATFORM_ID	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define PLATFORM_ID /;"	d	file:
-PLATFORM_ID	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define PLATFORM_ID$/;"	d	file:
-PLATFORM_ID	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define PLATFORM_ID /;"	d	file:
-PLATFORM_ID	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define PLATFORM_ID$/;"	d	file:
+MINGW	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^  set(MINGW 1)$/;"	v
+MINGW	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^  set(MINGW 1)$/;"	v
+PLATFORM_ID	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#  define PLATFORM_ID /;"	d	file:
+PLATFORM_ID	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#  define PLATFORM_ID$/;"	d	file:
+PLATFORM_ID	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^# define PLATFORM_ID /;"	d	file:
+PLATFORM_ID	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^# define PLATFORM_ID$/;"	d	file:
+PLATFORM_ID	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define PLATFORM_ID /;"	d	file:
+PLATFORM_ID	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define PLATFORM_ID$/;"	d	file:
+PLATFORM_ID	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define PLATFORM_ID /;"	d	file:
+PLATFORM_ID	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define PLATFORM_ID$/;"	d	file:
 Particle	particle.cpp	/^Particle::Particle() {$/;"	f	class:Particle
 Particle	particle.h	/^class Particle {$/;"	c
 RM	Makefile	/^RM := rm -r$/;"	m
 RM	build/Makefile	/^RM = \/usr\/bin\/cmake -E rm -f$/;"	m
-RNMX	Math/random.h	/^#define RNMX /;"	d
+Random	Math/random.h	/^    Random() {$/;"	f	class:Random
+Random	Math/random.h	/^    Random(int seed) {$/;"	f	class:Random
 Random	Math/random.h	/^class Random {$/;"	c
 RandomUniform	InitialStates/randomuniform.cpp	/^RandomUniform::RandomUniform(System*    system,$/;"	f	class:RandomUniform
 RandomUniform	InitialStates/randomuniform.h	/^class RandomUniform : public InitialState {$/;"	c
 SHELL	build/Makefile	/^SHELL = \/bin\/sh$/;"	m
-SIMULATE_ID	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#  define SIMULATE_ID /;"	d	file:
-SIMULATE_ID	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define SIMULATE_ID /;"	d	file:
-SIMULATE_VERSION_MAJOR	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#  define SIMULATE_VERSION_MAJOR /;"	d	file:
-SIMULATE_VERSION_MAJOR	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define SIMULATE_VERSION_MAJOR /;"	d	file:
-SIMULATE_VERSION_MINOR	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#  define SIMULATE_VERSION_MINOR /;"	d	file:
-SIMULATE_VERSION_MINOR	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define SIMULATE_VERSION_MINOR /;"	d	file:
-SIMULATE_VERSION_PATCH	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#  define SIMULATE_VERSION_PATCH /;"	d	file:
-SIMULATE_VERSION_PATCH	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define SIMULATE_VERSION_PATCH /;"	d	file:
-STRINGIFY	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#define STRINGIFY(/;"	d	file:
-STRINGIFY	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#define STRINGIFY(/;"	d	file:
-STRINGIFY_HELPER	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^#define STRINGIFY_HELPER(/;"	d	file:
-STRINGIFY_HELPER	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#define STRINGIFY_HELPER(/;"	d	file:
+SIMULATE_ID	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#  define SIMULATE_ID /;"	d	file:
+SIMULATE_ID	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^# define SIMULATE_ID /;"	d	file:
+SIMULATE_ID	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define SIMULATE_ID /;"	d	file:
+SIMULATE_ID	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define SIMULATE_ID /;"	d	file:
+SIMULATE_VERSION_MAJOR	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#  define SIMULATE_VERSION_MAJOR /;"	d	file:
+SIMULATE_VERSION_MAJOR	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^# define SIMULATE_VERSION_MAJOR /;"	d	file:
+SIMULATE_VERSION_MAJOR	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define SIMULATE_VERSION_MAJOR /;"	d	file:
+SIMULATE_VERSION_MAJOR	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define SIMULATE_VERSION_MAJOR /;"	d	file:
+SIMULATE_VERSION_MINOR	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#  define SIMULATE_VERSION_MINOR /;"	d	file:
+SIMULATE_VERSION_MINOR	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^# define SIMULATE_VERSION_MINOR /;"	d	file:
+SIMULATE_VERSION_MINOR	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define SIMULATE_VERSION_MINOR /;"	d	file:
+SIMULATE_VERSION_MINOR	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define SIMULATE_VERSION_MINOR /;"	d	file:
+SIMULATE_VERSION_PATCH	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#  define SIMULATE_VERSION_PATCH /;"	d	file:
+SIMULATE_VERSION_PATCH	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^# define SIMULATE_VERSION_PATCH /;"	d	file:
+SIMULATE_VERSION_PATCH	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#  define SIMULATE_VERSION_PATCH /;"	d	file:
+SIMULATE_VERSION_PATCH	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^# define SIMULATE_VERSION_PATCH /;"	d	file:
+STRINGIFY	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#define STRINGIFY(/;"	d	file:
+STRINGIFY	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#define STRINGIFY(/;"	d	file:
+STRINGIFY_HELPER	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^#define STRINGIFY_HELPER(/;"	d	file:
+STRINGIFY_HELPER	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^#define STRINGIFY_HELPER(/;"	d	file:
 Sampler	sampler.cpp	/^Sampler::Sampler(System* system) {$/;"	f	class:Sampler
 Sampler	sampler.h	/^class Sampler {$/;"	c
+SessionLoad	netrwsession.vim	/^let SessionLoad = 1$/;"	v
+SessionLoad	session.vim	/^let SessionLoad = 1$/;"	v
 Simple Variational Monte Carlo solve for FYS4411	README.md	/^# Simple Variational Monte Carlo solve for FYS4411$/;"	c
-SimpleGaussian	WaveFunctions/simplegaussian.cpp	/^SimpleGaussian::SimpleGaussian(System* system, double alpha) :$/;"	f	class:SimpleGaussian
+SimpleGaussian	WaveFunctions/simplegaussian.cpp	/^SimpleGaussian::SimpleGaussian(System* system, double alpha, double dt) :$/;"	f	class:SimpleGaussian
 SimpleGaussian	WaveFunctions/simplegaussian.h	/^class SimpleGaussian : public WaveFunction {$/;"	c
+System	system.cpp	/^System::System() {$/;"	f	class:System
+System	system.cpp	/^System::System(int seed) {$/;"	f	class:System
 System	system.h	/^class System {$/;"	c
-UNIX	build/CMakeFiles/3.19.3/CMakeCCompiler.cmake	/^  set(UNIX 1)$/;"	v
-UNIX	build/CMakeFiles/3.19.3/CMakeCXXCompiler.cmake	/^  set(UNIX 1)$/;"	v
+UNIX	build/CMakeFiles/3.20.0/CMakeCCompiler.cmake	/^  set(UNIX 1)$/;"	v
+UNIX	build/CMakeFiles/3.20.0/CMakeCXXCompiler.cmake	/^  set(UNIX 1)$/;"	v
 WaveFunction	WaveFunctions/wavefunction.cpp	/^WaveFunction::WaveFunction(System* system) {$/;"	f	class:WaveFunction
 WaveFunction	WaveFunctions/wavefunction.h	/^class WaveFunction {$/;"	c
 WaveFunctions/simplegaussian.i	build/Makefile	/^WaveFunctions\/simplegaussian.i:$/;"	t
@@ -277,23 +295,57 @@ WaveFunctions/simplegaussian.s	build/Makefile	/^WaveFunctions\/simplegaussian.s:
 WaveFunctions/wavefunction.i	build/Makefile	/^WaveFunctions\/wavefunction.i:$/;"	t
 WaveFunctions/wavefunction.o	build/Makefile	/^WaveFunctions\/wavefunction.o:$/;"	t
 WaveFunctions/wavefunction.s	build/Makefile	/^WaveFunctions\/wavefunction.s:$/;"	t
-Windows	README.md	/^#### Windows$/;"	t	subsection:Simple Variational Monte Carlo solve for FYS4411""Compilling and running the project""Compiling the project using CMake
+Wed. 3/2-21	changes.md	/^#	Wed. 3\/2-21$/;"	c
+Windows	README.md	/^#### Windows$/;"	t	subsection:Simple Variational Monte Carlo solve for FYS4411""Compiling and running the project""Compiling the project using CMake
+X	resampling.py	/^X = np.genfromtxt(infile, delimiter=";")$/;"	v
 adjustPosition	particle.cpp	/^void Particle::adjustPosition(double change, int dimension) {$/;"	f	class:Particle	typeref:typename:void
+algorithm	.vscode/settings.json	/^        "algorithm": "cpp",$/;"	s	object:files.associations
 all	build/Makefile	/^all: cmake_check_build_system$/;"	t
+array	.vscode/settings.json	/^        "array": "cpp",$/;"	s	object:files.associations
+atomic	.vscode/settings.json	/^        "atomic": "cpp",$/;"	s	object:files.associations
+cStandard	.vscode/c_cpp_properties.json	/^            "cStandard": "gnu17",$/;"	s	object:configurations.0
+cctype	.vscode/settings.json	/^        "cctype": "cpp",$/;"	s	object:files.associations
+chrono	.vscode/settings.json	/^        "chrono": "cpp",$/;"	s	object:files.associations
 clean	Makefile	/^clean:$/;"	t
 clean	build/Makefile	/^clean:$/;"	t
 clean/fast	build/Makefile	/^clean\/fast: clean$/;"	t
+clocale	.vscode/settings.json	/^        "clocale": "cpp",$/;"	s	object:files.associations
 cmake_check_build_system	build/Makefile	/^cmake_check_build_system:$/;"	t
 cmake_force	build/Makefile	/^cmake_force:$/;"	t
+cmath	.vscode/settings.json	/^        "cmath": "cpp",$/;"	s	object:files.associations
+codecvt	.vscode/settings.json	/^        "codecvt": "cpp"$/;"	s	object:files.associations
+compilerPath	.vscode/c_cpp_properties.json	/^            "compilerPath": "C:\\\\Program Files\\\\mingw-w64\\\\x86_64-8.1.0-posix-seh-rt_v6-re/;"	s	object:configurations.0
 computeAverages	sampler.cpp	/^void Sampler::computeAverages() {$/;"	f	class:Sampler	typeref:typename:void
-computeDoubleDerivative	WaveFunctions/simplegaussian.cpp	/^double SimpleGaussian::computeDoubleDerivative(std::vector<class Particle*> particles) {$/;"	f	class:SimpleGaussian	typeref:typename:double
+computeDerivative	WaveFunctions/simplegaussian.cpp	/^double SimpleGaussian::computeDerivative(std::vector<class Particle*> particles) {$/;"	f	class:SimpleGaussian	typeref:typename:double
+computeDoubleDerivative	WaveFunctions/simplegaussian.cpp	/^double SimpleGaussian::computeDoubleDerivative(double r2) {$/;"	f	class:SimpleGaussian	typeref:typename:double
 computeLocalEnergy	Hamiltonians/harmonicoscillator.cpp	/^double HarmonicOscillator::computeLocalEnergy(std::vector<Particle*> particles) {$/;"	f	class:HarmonicOscillator	typeref:typename:double
-const	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^# define const$/;"	d	file:
+configurations	.vscode/c_cpp_properties.json	/^    "configurations": [$/;"	a
+const	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^# define const$/;"	d	file:
+cppStandard	.vscode/c_cpp_properties.json	/^            "cppStandard": "gnu++14",$/;"	s	object:configurations.0
+cstdarg	.vscode/settings.json	/^        "cstdarg": "cpp",$/;"	s	object:files.associations
+cstddef	.vscode/settings.json	/^        "cstddef": "cpp",$/;"	s	object:files.associations
+cstdint	.vscode/settings.json	/^        "cstdint": "cpp",$/;"	s	object:files.associations
+cstdio	.vscode/settings.json	/^        "cstdio": "cpp",$/;"	s	object:files.associations
+cstdlib	.vscode/settings.json	/^        "cstdlib": "cpp",$/;"	s	object:files.associations
+ctime	.vscode/settings.json	/^        "ctime": "cpp",$/;"	s	object:files.associations
+cwchar	.vscode/settings.json	/^        "cwchar": "cpp",$/;"	s	object:files.associations
+cwctype	.vscode/settings.json	/^        "cwctype": "cpp",$/;"	s	object:files.associations
+data_path	resampling.py	/^def data_path(data_id): $/;"	f
 default_target	build/Makefile	/^default_target: all$/;"	t
+defines	.vscode/c_cpp_properties.json	/^            "defines": [$/;"	a	object:configurations.0
 depend	build/Makefile	/^depend:$/;"	t
+deque	.vscode/settings.json	/^        "deque": "cpp",$/;"	s	object:files.associations
 edit_cache	build/Makefile	/^edit_cache:$/;"	t
 edit_cache/fast	build/Makefile	/^edit_cache\/fast: edit_cache$/;"	t
 evaluate	WaveFunctions/simplegaussian.cpp	/^double SimpleGaussian::evaluate(std::vector<class Particle*> particles) {$/;"	f	class:SimpleGaussian	typeref:typename:double
+exception	.vscode/settings.json	/^        "exception": "cpp",$/;"	s	object:files.associations
+files.associations	.vscode/settings.json	/^    "files.associations": {$/;"	o
+filesystem	.vscode/settings.json	/^        "filesystem": "cpp",$/;"	s	object:files.associations
+fstream	.vscode/settings.json	/^        "fstream": "cpp",$/;"	s	object:files.associations
+functional	.vscode/settings.json	/^        "functional": "cpp",$/;"	s	object:files.associations
+getDeltaPsi	sampler.h	/^    double getDeltaPsi()        { return m_deltaPsi; }$/;"	f	class:Sampler	typeref:typename:double
+getDerivativePsiE	sampler.h	/^    double getDerivativePsiE()  { return m_derivativePsiE; }$/;"	f	class:Sampler	typeref:typename:double
+getElapsedTime	system.h	/^    double getElapsedTime()                      { return m_elapsed_time;}$/;"	f	class:System	typeref:typename:double
 getEnergy	sampler.h	/^    double getEnergy()          { return m_energy; }$/;"	f	class:Sampler	typeref:typename:double
 getEquilibrationFraction	system.h	/^    double getEquilibrationFraction()   { return m_equilibrationFraction; }$/;"	f	class:System	typeref:typename:double
 getHamiltonian	system.h	/^    class Hamiltonian*              getHamiltonian()    { return m_hamiltonian; }$/;"	f	class:System	typeref:class:System::getWaveFunction class Hamiltonian *
@@ -301,88 +353,131 @@ getNumberOfDimensions	system.h	/^    int getNumberOfDimensions()         { retur
 getNumberOfMetropolisSteps	system.h	/^    int getNumberOfMetropolisSteps()    { return m_numberOfMetropolisSteps; }$/;"	f	class:System	typeref:typename:int
 getNumberOfParameters	WaveFunctions/wavefunction.h	/^    int     getNumberOfParameters() { return m_numberOfParameters; }$/;"	f	class:WaveFunction	typeref:typename:int
 getNumberOfParticles	system.h	/^    int getNumberOfParticles()          { return m_numberOfParticles; }$/;"	f	class:System	typeref:typename:int
+getOutput	sampler.cpp	/^void Sampler::getOutput() {$/;"	f	class:Sampler	typeref:typename:void
 getParameters	WaveFunctions/wavefunction.h	/^    std::vector<double> getParameters() { return m_parameters; }$/;"	f	class:WaveFunction	typeref:typename:std::vector<double>
 getParticles	InitialStates/initialstate.h	/^    std::vector<class Particle*> getParticles() { return m_particles; }$/;"	c	class:InitialState
 getParticles	system.h	/^    std::vector<class Particle*>    getParticles()      { return m_particles; }$/;"	f	class:System	typeref:class:System::getSampler std::vector<class Particle * >
 getPosition	particle.h	/^    std::vector<double> getPosition() { return m_position; }$/;"	f	class:Particle	typeref:typename:std::vector<double>
+getRandomEngine	system.h	/^    class Random*                   getRandomEngine()   { return m_random; }$/;"	c	class:System
 getSampler	system.h	/^    class Sampler*                  getSampler()        { return m_sampler; }$/;"	c	class:System
+getSdRes	system.h	/^    std::vector<double>             getSdRes()          { return m_sdRes; }$/;"	f	class:System	typeref:class:System::getRandomEngine std::vector<double>
 getWaveFunction	system.h	/^    class WaveFunction*             getWaveFunction()   { return m_waveFunction; }$/;"	c	class:System
 help	build/Makefile	/^help:$/;"	t
-info_arch	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^char const* info_arch = "INFO" ":" "arch[" ARCHITECTURE_ID "]";$/;"	v	typeref:typename:char const *
-info_arch	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const* info_arch = "INFO" ":" "arch[" ARCHITECTURE_ID "]";$/;"	v	typeref:typename:char const *
-info_compiler	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^char const* info_compiler = "INFO" ":" "compiler[" COMPILER_ID "]";$/;"	v	typeref:typename:char const *
-info_compiler	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const* info_compiler = "INFO" ":" "compiler[" COMPILER_ID "]";$/;"	v	typeref:typename:char const *
-info_cray	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^char const *info_cray = "INFO" ":" "compiler_wrapper[CrayPrgEnv]";$/;"	v	typeref:typename:char const *
-info_cray	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const *info_cray = "INFO" ":" "compiler_wrapper[CrayPrgEnv]";$/;"	v	typeref:typename:char const *
-info_language_dialect_default	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^const char* info_language_dialect_default =$/;"	v	typeref:typename:const char *
-info_language_dialect_default	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^const char* info_language_dialect_default = "INFO" ":" "dialect_default["$/;"	v	typeref:typename:const char *
-info_platform	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^char const* info_platform = "INFO" ":" "platform[" PLATFORM_ID "]";$/;"	v	typeref:typename:char const *
-info_platform	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const* info_platform = "INFO" ":" "platform[" PLATFORM_ID "]";$/;"	v	typeref:typename:char const *
-info_simulate	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^char const* info_simulate = "INFO" ":" "simulate[" SIMULATE_ID "]";$/;"	v	typeref:typename:char const *
-info_simulate	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const* info_simulate = "INFO" ":" "simulate[" SIMULATE_ID "]";$/;"	v	typeref:typename:char const *
-info_simulate_version	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^char const info_simulate_version[] = {$/;"	v	typeref:typename:char const[]
-info_simulate_version	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const info_simulate_version[] = {$/;"	v	typeref:typename:char const[]
-info_version	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^char const info_version[] = {$/;"	v	typeref:typename:char const[]
-info_version	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const info_version[] = {$/;"	v	typeref:typename:char const[]
-info_version_internal	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^char const info_version_internal[] = {$/;"	v	typeref:typename:char const[]
-info_version_internal	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const info_version_internal[] = {$/;"	v	typeref:typename:char const[]
-iv	Math/random.cpp	/^long     Random::iv[NTAB];$/;"	m	class:Random	typeref:typename:long[]
-iv	Math/random.h	/^    static long iv[NTAB];$/;"	m	class:Random	typeref:typename:long[]
-iy	Math/random.cpp	/^long     Random::iy = 0;$/;"	m	class:Random	typeref:typename:long
-iy	Math/random.h	/^    static long iy;$/;"	m	class:Random	typeref:typename:long
-m_cumulativeEnergy	sampler.h	/^    double  m_cumulativeEnergy = 0;$/;"	m	class:Sampler	typeref:typename:double
-m_energy	sampler.h	/^    double  m_energy = 0;$/;"	m	class:Sampler	typeref:typename:double
+importanceSamplingStep	system.cpp	/^bool System::importanceSamplingStep(int particle) {$/;"	f	class:System	typeref:typename:bool
+includePath	.vscode/c_cpp_properties.json	/^            "includePath": [$/;"	a	object:configurations.0
+infile	resampling.py	/^infile = open(data_path("energies.csv"), "r")$/;"	v
+info_arch	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^char const* info_arch = "INFO" ":" "arch[" ARCHITECTURE_ID "]";$/;"	v	typeref:typename:char const *
+info_arch	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const* info_arch = "INFO" ":" "arch[" ARCHITECTURE_ID "]";$/;"	v	typeref:typename:char const *
+info_compiler	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^char const* info_compiler = "INFO" ":" "compiler[" COMPILER_ID "]";$/;"	v	typeref:typename:char const *
+info_compiler	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const* info_compiler = "INFO" ":" "compiler[" COMPILER_ID "]";$/;"	v	typeref:typename:char const *
+info_cray	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^char const *info_cray = "INFO" ":" "compiler_wrapper[CrayPrgEnv]";$/;"	v	typeref:typename:char const *
+info_cray	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const *info_cray = "INFO" ":" "compiler_wrapper[CrayPrgEnv]";$/;"	v	typeref:typename:char const *
+info_language_dialect_default	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^const char* info_language_dialect_default =$/;"	v	typeref:typename:const char *
+info_language_dialect_default	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^const char* info_language_dialect_default = "INFO" ":" "dialect_default["$/;"	v	typeref:typename:const char *
+info_platform	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^char const* info_platform = "INFO" ":" "platform[" PLATFORM_ID "]";$/;"	v	typeref:typename:char const *
+info_platform	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const* info_platform = "INFO" ":" "platform[" PLATFORM_ID "]";$/;"	v	typeref:typename:char const *
+info_simulate	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^char const* info_simulate = "INFO" ":" "simulate[" SIMULATE_ID "]";$/;"	v	typeref:typename:char const *
+info_simulate	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const* info_simulate = "INFO" ":" "simulate[" SIMULATE_ID "]";$/;"	v	typeref:typename:char const *
+info_simulate_version	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^char const info_simulate_version[] = {$/;"	v	typeref:typename:char const[]
+info_simulate_version	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const info_simulate_version[] = {$/;"	v	typeref:typename:char const[]
+info_version	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^char const info_version[] = {$/;"	v	typeref:typename:char const[]
+info_version	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const info_version[] = {$/;"	v	typeref:typename:char const[]
+info_version_internal	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^char const info_version_internal[] = {$/;"	v	typeref:typename:char const[]
+info_version_internal	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const info_version_internal[] = {$/;"	v	typeref:typename:char const[]
+initializer_list	.vscode/settings.json	/^        "initializer_list": "cpp",$/;"	s	object:files.associations
+intelliSenseMode	.vscode/c_cpp_properties.json	/^            "intelliSenseMode": "windows-gcc-x64"$/;"	s	object:configurations.0
+iosfwd	.vscode/settings.json	/^        "iosfwd": "cpp",$/;"	s	object:files.associations
+iostream	.vscode/settings.json	/^        "iostream": "cpp",$/;"	s	object:files.associations
+istream	.vscode/settings.json	/^        "istream": "cpp",$/;"	s	object:files.associations
+iterator	.vscode/settings.json	/^        "iterator": "cpp",$/;"	s	object:files.associations
+limits	.vscode/settings.json	/^        "limits": "cpp",$/;"	s	object:files.associations
+m_accepted	sampler.h	/^	int					m_accepted = 0;$/;"	m	class:Sampler	typeref:typename:int
+m_cumulativeEnergy	sampler.h	/^    double              m_cumulativeEnergy = 0;$/;"	m	class:Sampler	typeref:typename:double
+m_deltaPsi	sampler.h	/^    double              m_deltaPsi = 0;$/;"	m	class:Sampler	typeref:typename:double
+m_derivativePsiE	sampler.h	/^    double              m_derivativePsiE = 0;$/;"	m	class:Sampler	typeref:typename:double
+m_elapsed_time	system.h	/^    double m_elapsed_time;$/;"	m	class:System	typeref:typename:double
+m_energies	sampler.h	/^    std::vector<double> m_energies = std::vector<double>();$/;"	m	class:Sampler	typeref:typename:std::vector<double>
+m_energy	sampler.h	/^    double              m_energy = 0;$/;"	m	class:Sampler	typeref:typename:double
+m_engine	Math/random.h	/^    std::mt19937_64 m_engine;$/;"	m	class:Random	typeref:typename:std::mt19937_64
 m_equilibrationFraction	system.h	/^    double                          m_equilibrationFraction = 0.0;$/;"	m	class:System	typeref:typename:double
 m_hamiltonian	system.h	/^    class Hamiltonian*              m_hamiltonian = nullptr;$/;"	m	class:System	typeref:class:Hamiltonian *
 m_initialState	system.h	/^    class InitialState*             m_initialState = nullptr;$/;"	m	class:System	typeref:class:InitialState *
+m_mode	Hamiltonians/harmonicoscillator.h	/^	bool m_mode = true;$/;"	m	class:HarmonicOscillator	typeref:typename:bool
 m_numberOfDimensions	InitialStates/initialstate.h	/^    int m_numberOfDimensions = 0;$/;"	m	class:InitialState	typeref:typename:int
 m_numberOfDimensions	particle.h	/^    int     m_numberOfDimensions = 0;$/;"	m	class:Particle	typeref:typename:int
 m_numberOfDimensions	system.h	/^    int                             m_numberOfDimensions = 0;$/;"	m	class:System	typeref:typename:int
-m_numberOfMetropolisSteps	sampler.h	/^    int     m_numberOfMetropolisSteps = 0;$/;"	m	class:Sampler	typeref:typename:int
+m_numberOfMetropolisSteps	sampler.h	/^    int                 m_numberOfMetropolisSteps = 0;$/;"	m	class:Sampler	typeref:typename:int
 m_numberOfMetropolisSteps	system.h	/^    int                             m_numberOfMetropolisSteps = 0;$/;"	m	class:System	typeref:typename:int
 m_numberOfParameters	WaveFunctions/wavefunction.h	/^    int     m_numberOfParameters = 0;$/;"	m	class:WaveFunction	typeref:typename:int
 m_numberOfParticles	InitialStates/initialstate.h	/^    int m_numberOfParticles = 0;$/;"	m	class:InitialState	typeref:typename:int
 m_numberOfParticles	system.h	/^    int                             m_numberOfParticles = 0;$/;"	m	class:System	typeref:typename:int
 m_omega	Hamiltonians/harmonicoscillator.h	/^    double m_omega = 0;$/;"	m	class:HarmonicOscillator	typeref:typename:double
+m_output	sampler.h	/^    std::string         m_output = "";$/;"	m	class:Sampler	typeref:typename:std::string
 m_parameters	WaveFunctions/wavefunction.h	/^    std::vector<double> m_parameters = std::vector<double>();$/;"	m	class:WaveFunction	typeref:typename:std::vector<double>
-m_particles	InitialStates/initialstate.h	/^    std::vector<Particle*> m_particles;\/\/ = std::vector<Particle*>();$/;"	m	class:InitialState	typeref:typename:std::vector<Particle * >
+m_particles	InitialStates/initialstate.h	/^    std::vector<Particle*> m_particles = std::vector<Particle*>();$/;"	m	class:InitialState	typeref:typename:std::vector<Particle * >
 m_position	particle.h	/^    std::vector<double> m_position = std::vector<double>();$/;"	m	class:Particle	typeref:typename:std::vector<double>
+m_positions	sampler.h	/^    std::vector<std::vector<std::vector<double>>> m_positions = std::vector<std::vector<std::vec/;"	m	class:Sampler	typeref:typename:std::vector<std::vector<std::vector<double>>>
+m_random	system.h	/^    class Random*                   m_random = nullptr;$/;"	m	class:System	typeref:class:Random *
 m_sampler	system.h	/^    class Sampler*                  m_sampler = nullptr;$/;"	m	class:System	typeref:class:Sampler *
 m_stepLength	system.h	/^    double                          m_stepLength = 0.1;$/;"	m	class:System	typeref:typename:double
-m_stepNumber	sampler.h	/^    int     m_stepNumber = 0;$/;"	m	class:Sampler	typeref:typename:int
+m_stepNumber	sampler.h	/^    int                 m_stepNumber = 0;$/;"	m	class:Sampler	typeref:typename:int
 m_system	Hamiltonians/hamiltonian.h	/^    class System* m_system = nullptr;$/;"	m	class:Hamiltonian	typeref:class:System *
 m_system	WaveFunctions/wavefunction.h	/^    class System* m_system = nullptr;$/;"	m	class:WaveFunction	typeref:class:System *
 m_system	sampler.h	/^    class System* m_system = nullptr;$/;"	m	class:Sampler	typeref:class:System *
+m_time_start	system.h	/^    std::chrono::time_point<std::chrono::system_clock> m_time_start;$/;"	m	class:System	typeref:typename:std::chrono::time_point<std::chrono::system_clock>
 m_waveFunction	system.h	/^    class WaveFunction*             m_waveFunction = nullptr;$/;"	m	class:System	typeref:class:WaveFunction *
-main	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^int main(argc, argv) int argc; char *argv[];$/;"	f
-main	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^void main() {}$/;"	f	typeref:typename:void
-main	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^int main(int argc, char* argv[])$/;"	f	typeref:typename:int
+main	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^int main(argc, argv) int argc; char *argv[];$/;"	f
+main	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^void main() {}$/;"	f	typeref:typename:void
+main	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^int main(int argc, char* argv[])$/;"	f	typeref:typename:int
 main	main.cpp	/^int main() {$/;"	f	typeref:typename:int
 main.i	build/Makefile	/^main.i:$/;"	t
 main.o	build/Makefile	/^main.o:$/;"	t
 main.s	build/Makefile	/^main.s:$/;"	t
-metropolisStep	system.cpp	/^bool System::metropolisStep() {$/;"	f	class:System	typeref:typename:bool
-nextDouble	Math/random.cpp	/^double Random::nextDouble()$/;"	f	class:Random	typeref:typename:double
-nextGaussian	Math/random.cpp	/^double Random::nextGaussian(double mean, double standardDeviation) {$/;"	f	class:Random	typeref:typename:double
-nextInt	Math/random.cpp	/^int Random::nextInt(int upperLimit) {$/;"	f	class:Random	typeref:typename:int
+memory	.vscode/settings.json	/^        "memory": "cpp",$/;"	s	object:files.associations
+memory_resource	.vscode/settings.json	/^        "memory_resource": "cpp",$/;"	s	object:files.associations
+metropolisStep	system.cpp	/^bool System::metropolisStep(int particle) {$/;"	f	class:System	typeref:typename:bool
+name	.vscode/c_cpp_properties.json	/^            "name": "Win32",$/;"	s	object:configurations.0
+new	.vscode/settings.json	/^        "new": "cpp",$/;"	s	object:files.associations
+nextDouble	Math/random.h	/^    double nextDouble() {$/;"	f	class:Random	typeref:typename:double
+nextGaussian	Math/random.h	/^    double nextGaussian($/;"	f	class:Random	typeref:typename:double
+nextInt	Math/random.h	/^    int nextInt(const int &lowerLimit, const int &upperLimit) {$/;"	f	class:Random	typeref:typename:int
+nextInt	Math/random.h	/^    int nextInt(const int &upperLimit) {$/;"	f	class:Random	typeref:typename:int
+np	resampling.py	/^import numpy as np$/;"	I	nameref:module:numpy
+numeric	.vscode/settings.json	/^        "numeric": "cpp",$/;"	s	object:files.associations
+numeric	Hamiltonians/hamiltonian.cpp	/^double Hamiltonian::numeric()$/;"	f	class:Hamiltonian	typeref:typename:double
+optional	.vscode/settings.json	/^        "optional": "cpp",$/;"	s	object:files.associations
+ostream	.vscode/settings.json	/^        "ostream": "cpp",$/;"	s	object:files.associations
 particle.i	build/Makefile	/^particle.i:$/;"	t
 particle.o	build/Makefile	/^particle.o:$/;"	t
 particle.s	build/Makefile	/^particle.s:$/;"	t
 preinstall	build/Makefile	/^preinstall: all$/;"	t
 preinstall/fast	build/Makefile	/^preinstall\/fast:$/;"	t
+printOutputToFile	sampler.cpp	/^void Sampler::printOutputToFile() {$/;"	f	class:Sampler	typeref:typename:void
 printOutputToTerminal	sampler.cpp	/^void Sampler::printOutputToTerminal() {$/;"	f	class:Sampler	typeref:typename:void
 project_1_fys4411	CMakeLists.txt	/^project(project_1_fys4411)$/;"	p
-qnxnto	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^char const* qnxnto = "INFO" ":" "qnxnto[]";$/;"	v	typeref:typename:char const *
-qnxnto	build/CMakeFiles/3.19.3/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const* qnxnto = "INFO" ":" "qnxnto[]";$/;"	v	typeref:typename:char const *
+qnxnto	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^char const* qnxnto = "INFO" ":" "qnxnto[]";$/;"	v	typeref:typename:char const *
+qnxnto	build/CMakeFiles/3.20.0/CompilerIdCXX/CMakeCXXCompilerId.cpp	/^char const* qnxnto = "INFO" ":" "qnxnto[]";$/;"	v	typeref:typename:char const *
+quantumForce	system.cpp	/^std::vector<double> System::quantumForce(int particle) {$/;"	f	class:System	typeref:typename:std::vector<double>
+random	.vscode/settings.json	/^        "random": "cpp",$/;"	s	object:files.associations
+ratio	.vscode/settings.json	/^        "ratio": "cpp",$/;"	s	object:files.associations
 rebuild_cache	build/Makefile	/^rebuild_cache:$/;"	t
 rebuild_cache/fast	build/Makefile	/^rebuild_cache\/fast: rebuild_cache$/;"	t
-runMetropolisSteps	system.cpp	/^void System::runMetropolisSteps(int numberOfMetropolisSteps) {$/;"	f	class:System	typeref:typename:void
+runImportanceSamplingSteps	system.cpp	/^void System::runImportanceSamplingSteps(int numberOfMetropolisSteps, bool saveData) {$/;"	f	class:System	typeref:typename:void
+runMetropolisSteps	system.cpp	/^void System::runMetropolisSteps(int numberOfMetropolisSteps, bool saveData) {$/;"	f	class:System	typeref:typename:void
+s:l	netrwsession.vim	/^let s:l = 31 - ((30 * winheight(0) + 22) \/ 45)$/;"	v
+s:l	netrwsession.vim	/^let s:l = 53 - ((43 * winheight(0) + 22) \/ 45)$/;"	v
+s:l	session.vim	/^let s:l = 48 - ((40 * winheight(0) + 22) \/ 45)$/;"	v
+s:l	session.vim	/^let s:l = 52 - ((26 * winheight(0) + 22) \/ 45)$/;"	v
+s:so_save	netrwsession.vim	/^let s:so_save = &so | let s:siso_save = &siso | set so=0 siso=0$/;"	v
+s:so_save	session.vim	/^let s:so_save = &so | let s:siso_save = &siso | set so=0 siso=0$/;"	v
+s:sx	netrwsession.vim	/^let s:sx = expand("<sfile>:p:r")."x.vim"$/;"	v
+s:sx	session.vim	/^let s:sx = expand("<sfile>:p:r")."x.vim"$/;"	v
+s:wipebuf	netrwsession.vim	/^  let s:wipebuf = bufnr('%')$/;"	v
+s:wipebuf	session.vim	/^  let s:wipebuf = bufnr('%')$/;"	v
 sample	sampler.cpp	/^void Sampler::sample(bool acceptedStep) {$/;"	f	class:Sampler	typeref:typename:void
 sampler.i	build/Makefile	/^sampler.i:$/;"	t
 sampler.o	build/Makefile	/^sampler.o:$/;"	t
 sampler.s	build/Makefile	/^sampler.s:$/;"	t
-seed	Math/random.cpp	/^long     Random::seed = -1;$/;"	m	class:Random	typeref:typename:long
-seed	Math/random.h	/^    static long seed;$/;"	m	class:Random	typeref:typename:long
 setEquilibrationFraction	system.cpp	/^void System::setEquilibrationFraction(double equilibrationFraction) {$/;"	f	class:System	typeref:typename:void
 setHamiltonian	system.cpp	/^void System::setHamiltonian(Hamiltonian* hamiltonian) {$/;"	f	class:System	typeref:typename:void
 setInitialState	system.cpp	/^void System::setInitialState(InitialState* initialState) {$/;"	f	class:System	typeref:typename:void
@@ -391,14 +486,30 @@ setNumberOfDimensions	system.cpp	/^void System::setNumberOfDimensions(int number
 setNumberOfMetropolisSteps	sampler.cpp	/^void Sampler::setNumberOfMetropolisSteps(int steps) {$/;"	f	class:Sampler	typeref:typename:void
 setNumberOfParticles	system.cpp	/^void System::setNumberOfParticles(int numberOfParticles) {$/;"	f	class:System	typeref:typename:void
 setPosition	particle.cpp	/^void Particle::setPosition(const std::vector<double> &position) {$/;"	f	class:Particle	typeref:typename:void
-setSeed	Math/random.cpp	/^void Random::setSeed(long seed) {$/;"	f	class:Random	typeref:typename:void
 setStepLength	system.cpp	/^void System::setStepLength(double stepLength) {$/;"	f	class:System	typeref:typename:void
 setWaveFunction	system.cpp	/^void System::setWaveFunction(WaveFunction* waveFunction) {$/;"	f	class:System	typeref:typename:void
 setupInitialState	InitialStates/randomuniform.cpp	/^void RandomUniform::setupInitialState() {$/;"	f	class:RandomUniform	typeref:typename:void
+sstream	.vscode/settings.json	/^        "sstream": "cpp",$/;"	s	object:files.associations
+stat	resampling.py	/^def stat(data):$/;"	f
+stdexcept	.vscode/settings.json	/^        "stdexcept": "cpp",$/;"	s	object:files.associations
+streambuf	.vscode/settings.json	/^        "streambuf": "cpp",$/;"	s	object:files.associations
+string	.vscode/settings.json	/^        "string": "cpp",$/;"	s	object:files.associations
+string_view	.vscode/settings.json	/^        "string_view": "cpp",$/;"	s	object:files.associations
 system.i	build/Makefile	/^system.i:$/;"	t
 system.o	build/Makefile	/^system.o:$/;"	t
 system.s	build/Makefile	/^system.s:$/;"	t
+system_error	.vscode/settings.json	/^        "system_error": "cpp",$/;"	s	object:files.associations
+t	resampling.py	/^t = tsboot(X, stat, np.shape(X)[0], 2**10)$/;"	v
+tsboot	resampling.py	/^def tsboot(data, statistic, R, l):$/;"	f
+tuple	.vscode/settings.json	/^        "tuple": "cpp",$/;"	s	object:files.associations
+type_traits	.vscode/settings.json	/^        "type_traits": "cpp",$/;"	s	object:files.associations
+typeinfo	.vscode/settings.json	/^        "typeinfo": "cpp",$/;"	s	object:files.associations
+unordered_map	.vscode/settings.json	/^        "unordered_map": "cpp",$/;"	s	object:files.associations
+utility	.vscode/settings.json	/^        "utility": "cpp",$/;"	s	object:files.associations
+vector	.vscode/settings.json	/^        "vector": "cpp",$/;"	s	object:files.associations
+vector	system.h	/^    std::vector<double>             m_sdRes = std::vector<double> {};$/;"	c	class:System::std
+version	.vscode/c_cpp_properties.json	/^    "version": 4$/;"	n
 vmc	CMakeLists.txt	/^add_executable(vmc ${SOURCES})$/;"	t
 vmc	build/Makefile	/^vmc: cmake_check_build_system$/;"	t
 vmc/fast	build/Makefile	/^vmc\/fast:$/;"	t
-volatile	build/CMakeFiles/3.19.3/CompilerIdC/CMakeCCompilerId.c	/^# define volatile$/;"	d	file:
+volatile	build/CMakeFiles/3.20.0/CompilerIdC/CMakeCCompilerId.c	/^# define volatile$/;"	d	file:


### PR DESCRIPTION
in itself is unchanged. main has also had a change in number of
dimensions and particles, mc steps and eta size in order to try and find
out why results differ on an linux setup to macOS and windows.
    Thoughts on this so far is differences in handling of pointers
    and/or initialisations not set to 0. in essence undefined
    behaviours.
    Might be noteworthy that linux distribution is archlinux and the
    rolling release packages could be newer than the others.

the python script reads the 1st line in the energies.csv file in
"results_1c" folder and performs a bootstrap resampling on it, producing
both an overall bias and std.deviation but also a histogram with the
fit.