### PR TITLE
energies seems to have had an issue with 2 numbers lacking a ";" to

### DIFF
--- a/blocking.py
+++ b/blocking.py
@@ -9,9 +9,10 @@ from numpy import log2, floor, array, zeros, mean, arange, cumsum, var, loadtxt
 import numpy.linalg as lin
 import os
 import csv
+import re
 
 
-DATA_ID = "results_1c"
+DATA_ID = "results"
 
 def data_path(data_id): 
     return os.path.join(DATA_ID, data_id)
@@ -68,9 +69,26 @@ runexample:
     $ standard error = 0.00392796
 """
 #read in data
-infile = open(data_path("energies.csv"), "r")
+#1c
+print("1c) ")
+infile = open(data_path("energies_1c.csv"), "r")
 csv_reader = csv.reader(infile, delimiter=";")
+i = 0
 for row in csv_reader:
+    print("*"*50)
+    row = list(filter(None, row))
     X = array(row, dtype=float)
     print("standard error = %g" %block(X)**.5)
-    break
+infile.close()
+
+#1d
+print("1d) ")
+infile = open(data_path("energies_1d.csv"), "r")
+csv_reader = csv.reader(infile, delimiter=";")
+for row in csv_reader:
+    print("*"*50)
+    row = list(filter(None, row))
+    X = array(row, dtype=float)
+    print("standard error = %g" %block(X)**.5)
+    #break
+infile.close()


### PR DESCRIPTION
blocking now runs through the data necessary. the next step would probably be to somehow check for the number of particles and dimensions of the runs. then storing the information somehow. there were a few issues wrt. the energies csv file. 2 numbers were lacking a separating ";" which I removed in the file itself. uncertain how to automate such. there was a trailing ";" as well, which I managed to strip. <- this last step adds about a seconds to the runtime of the program. 